### PR TITLE
ERC20 transfers exporter Node image downgrade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ WORKDIR /app
 
 COPY package.json package-lock.json /app/
 
-RUN npm install --production
+RUN npm install
 
 FROM node:9.11.1-alpine
 

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "description": "Exporter of all transfer events from the ERC20 tokens",
   "main": "index.js",
   "scripts": {
-    "test": "./node_modules/.bin/mocha --reporter spec",
-    "lint": "./node_modules/.bin/jslint '**/*.js'",
-    "start": "./node_modules/.bin/micro index.js"
+    "test": "mocha --reporter spec",
+    "lint": "jslint '**/*.js'",
+    "start": "micro index.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This is a temporary decrease of the base docker image used for the ERC20 transfers exporter. Using the newer image has presented a problem of the docker container not always starting on deploy.