### PR TITLE
Lower mapped contracts upon reading from json.

### DIFF
--- a/lib/contract_overwrite.js
+++ b/lib/contract_overwrite.js
@@ -10,13 +10,14 @@ var BigNumber = require('bignumber.js');
  */
 class ContractOverwrite {
   constructor(parsedContract) {
-    this.newContract = parsedContract.new_address;
+    this.newContract = parsedContract.new_address.toLowerCase();
     this.oldAddresses = []
     this.mapAddressToMultiplier = {};
 
     for (const oldContract of parsedContract.old_contracts) {
-      this.oldAddresses.push(oldContract.address);
-      this.mapAddressToMultiplier[oldContract.address] = oldContract.multiplier;
+      const oldContractLower = oldContract.address.toLowerCase()
+      this.oldAddresses.push(oldContractLower);
+      this.mapAddressToMultiplier[oldContractLower] = oldContract.multiplier;
     }
   }
 }


### PR DESCRIPTION
One of the on-chain contracts for "Reputation" is specified with mixed case in our json mapping file. This has led to the contract not being recognized and not being mapped. To prevent this, lower address upon reading from the json file.