### PR TITLE
Bugfix in array concatenation

### DIFF
--- a/blockchains/erc20/lib/contract_overwrite.js
+++ b/blockchains/erc20/lib/contract_overwrite.js
@@ -28,7 +28,7 @@ class ContractEditor {
     this.contractsOverwriteArray = parsedContracts.map((parsedContract) => new ContractOverwrite(parsedContract))
 
     logger.info(`Running in 'exact contracts mode', ${this.contractsOverwriteArray.length} contracts will be monitored.`)
-    logger.info("Overwritten contracts are:")
+    logger.info(`Overwritten contracts are: ${JSON.stringify(this.contractsOverwriteArray)}`)
   }
 
   isContractMatchesExactList(event, contractOverwrite) {
@@ -56,7 +56,7 @@ class ContractEditor {
 
     for (const contractOverwrite of this.contractsOverwriteArray) {
       const events = await getPastEvents(web3, fromBlock, toBlock, contractOverwrite.oldAddresses)
-      resultsAggregation.concat(events)
+      resultsAggregation = resultsAggregation.concat(events)
     }
 
     return resultsAggregation

--- a/test/erc20/contract_overwrite.spec.js
+++ b/test/erc20/contract_overwrite.spec.js
@@ -5,14 +5,12 @@ const Web3 = require('web3')
 
 const fetch_events = rewire("../../blockchains/erc20/lib/fetch_events")
 const {contractEditor} = require("../../blockchains/erc20/lib/contract_overwrite")
+const contract_overwrite = rewire("../../blockchains/erc20/lib/contract_overwrite")
 const web3 = new Web3()
 
 const SNXContractLegacy = '0xc011a72400e58ecd99ee497cf89e3775d4bd732f'
 const SNXContractNew = '0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f'
 const SNXContractReplacer = 'snx_contract'
-const sUSDContractLegacy = '0x57ab1e02fee23774580c119740129eac7081e9d3'
-const sUSDContractNew = '0x57ab1ec28d129707052df4df418d58a2d46d5f51'
-const sUSDContractReplacer = 'susd_contract'
 
 const rawEventNotSNX = {
   address: '0xdAC17F958D2ee523a2206206994597C13D831ec7',
@@ -158,4 +156,18 @@ describe('contract manipulations', function() {
         [decodedEventNotSNX, decodedEventSNXLegacy, correctedEventSNXLegacy, decodedEventSNXNew, correctedEventSNXNew]
     )
   })
+
+  it("test getPastEventsExactContracts correctly concatenates events", async function() {
+    contract_overwrite.__set__("getPastEvents", function () {
+      return ["a", "b", "c"]
+    })
+    contract_overwrite.contractEditor.contractsOverwriteArray = ["contract1", "contract2"]
+
+    let result = await contract_overwrite.contractEditor.getPastEventsExactContracts()
+    assert.deepStrictEqual(
+      result,
+      ["a", "b", "c", "a", "b", "c"]
+  )
+  })
+
 })


### PR DESCRIPTION
At a previous PR:
https://github.com/santiment/san-chain-exporter/pull/41/files#diff-3373a5e8bd40e74b4f0f10cc408d4e8cc212e3624ca0ed7c19d16ec808275aa0R59
I have introduced a bug in array concatenation. Fix along with a test.