### PR TITLE
Resolve promise returned by register.metrics()

### DIFF
--- a/index.js
+++ b/index.js
@@ -115,7 +115,7 @@ module.exports = async (request, response) => {
           })
     case '/metrics':
       response.setHeader('Content-Type', metrics.register.contentType);
-      return send(response, 200, metrics.register.metrics());
+      return send(response, 200, await metrics.register.metrics())
     default:
       return send(response, 404, 'Not found');
   }


### PR DESCRIPTION
In this PR a fix for missing metrics. register.metrics() returns a promise which we need to resolve. Not sure how that worked in previous versions of the code because from what I saw the Promise was also not resolved. Anyways.