### PR TITLE
Fix setting of primary keys for overwritten contracts

### DIFF
--- a/blockchains/erc20/erc20_worker.js
+++ b/blockchains/erc20/erc20_worker.js
@@ -46,6 +46,7 @@ class ERC20Worker extends BaseWorker {
     logger.info(`Fetching transfer events for interval ${this.lastExportedBlock}:${toBlock}`)
 
     let events = [];
+    let overwritten_events = []
     if ("extract_exact_overwrite" == constants.CONTRACT_MODE) {
       events = await contractEditor.getPastEventsExactContracts(this.web3, this.lastExportedBlock + 1, toBlock)
       events = contractEditor.changeContractAddresses(events)
@@ -53,12 +54,12 @@ class ERC20Worker extends BaseWorker {
     else {
       events = await getPastEvents(this.web3, this.lastExportedBlock + 1, toBlock)
       if ("extract_all_append" == constants.CONTRACT_MODE) {
-        events = contractEditor.changeContractAddresses(events, false, true)
+        overwritten_events = contractEditor.extractChangedContractAddresses(events)
       }
     }
 
     if (events.length > 0) {
-      extendEventsWithPrimaryKey(events)
+      extendEventsWithPrimaryKey(events, overwritten_events)
       logger.info(`Setting primary keys ${events.length} messages for blocks ${this.lastExportedBlock + 1}:${toBlock}`)
       this.lastPrimaryKey = events[events.length - 1].primaryKey
     }

--- a/blockchains/erc20/lib/contract_overwrite.js
+++ b/blockchains/erc20/lib/contract_overwrite.js
@@ -62,26 +62,39 @@ class ContractEditor {
     return resultsAggregation
   }
 
-  changeContractAddresses(events,
-                          deepCopy = false,
-                          keepOriginal = false) {
+  /**
+   *
+   * @param events A list of events to go over and check contract address. Events needing contract change will
+   * have the change applied.
+   */
+  changeContractAddresses(events) {
+    for(let event of events) {
+      for (const contractOverwrite of this.contractsOverwriteArray) {
+        if (this.isContractMatchesExactList(event, contractOverwrite)) {
+          this.editAddressAndAmount(event, contractOverwrite)
+          break
+        }
+      }
+    }
+  }
+
+  /**
+   *
+   * @param events A list of events to go over and check contract address.
+   * @returns A deep copy of the events which have had change applied.
+   */
+   extractChangedContractAddresses(events) {
     const result = []
 
     for(let event of events) {
       for (const contractOverwrite of this.contractsOverwriteArray) {
         if (this.isContractMatchesExactList(event, contractOverwrite)) {
-          if (keepOriginal) {
-            const clone = JSON.parse(JSON.stringify(event))
-            result.push(clone)
-          }
-          if (deepCopy) {
-            event = JSON.parse(JSON.stringify(event))
-          }
+          event = JSON.parse(JSON.stringify(event))
           this.editAddressAndAmount(event, contractOverwrite)
+          result.push(event)
           break
         }
       }
-      result.push(event)
     }
 
     return result

--- a/blockchains/erc20/lib/extend_events_key.js
+++ b/blockchains/erc20/lib/extend_events_key.js
@@ -14,15 +14,23 @@ function transactionOrder(a, b) {
   }
 }
 
-function extendEventsWithPrimaryKey(events) {
+function extendEventsWithPrimaryKey(events, overwritten_events) {
   stableSort(events, transactionOrder)
   const lastEvent = events[events.length -1]
-  if (lastEvent.logIndex >= constants.PRIMARY_KEY_MULTIPLIER) {
-    logger.error(`An event with log index ${lastEvent.logIndex} is breaking the primaryKey generation logic at block ${lastEvent.blockNumber}`)
+  if (lastEvent.logIndex + overwritten_events.length >= constants.PRIMARY_KEY_MULTIPLIER) {
+    logger.error(`An event with log index ${lastEvent.logIndex} is breaking the primaryKey generation logic at block `
+     + `${lastEvent.blockNumber}. There are ${overwritten_events.length} overwritten events.`)
   }
 
   events.forEach( function(event) {
     event.primaryKey = event.blockNumber * constants.PRIMARY_KEY_MULTIPLIER + event.logIndex
+  })
+  // As the overwritten events are copies of the main events, they would have the same logIndex. To generate unique primary keys,
+  // the primary keys of ovewritten events start after the biggest primary key of the main events and increase by 1.
+  let lastLogIndex = lastEvent.logIndex
+  overwritten_events.forEach( function(event) {
+    lastLogIndex += 1
+    event.primaryKey = event.blockNumber * constants.PRIMARY_KEY_MULTIPLIER + lastLogIndex
   })
 }
 

--- a/test/erc20/contract_overwrite.spec.js
+++ b/test/erc20/contract_overwrite.spec.js
@@ -130,31 +130,33 @@ describe('contract manipulations', function() {
     )
   })
 
-  it("change contract addresses", async function() {
-    const editedEvents = contractEditor.changeContractAddresses([
-      decodedEventNotSNX,
-      decodedEventSNXLegacy,
-      decodedEventSNXNew
-    ],
-        true)
+  it("change contract addresses deep copy", async function() {
+    const inputEvents = [decodedEventNotSNX, decodedEventSNXLegacy, decodedEventSNXNew]
+    const editedEvents = contractEditor.extractChangedContractAddresses(inputEvents)
 
     assert.deepStrictEqual(
         editedEvents,
+        [correctedEventSNXLegacy, correctedEventSNXNew]
+    )
+  })
+
+  it("change contract addresses shallow copy", async function() {
+    const inputEvents = [decodedEventNotSNX, decodedEventSNXLegacy, decodedEventSNXNew]
+    contractEditor.changeContractAddresses(inputEvents)
+
+    assert.deepStrictEqual(
+        inputEvents,
         [decodedEventNotSNX, correctedEventSNXLegacy, correctedEventSNXNew]
     )
   })
 
-  it("append events with changed contract addresses", async function() {
-    const editedEvents = contractEditor.changeContractAddresses(
-        [decodedEventNotSNX, decodedEventSNXLegacy, decodedEventSNXNew],
-        true,
-        true
-    )
+  it("input events are not modified on contract edit and deep copy", async function() {
+    const inputEvents = [decodedEventNotSNX, decodedEventSNXLegacy, decodedEventSNXNew]
+    const inputEventsCopy = JSON.stringify(inputEvents)
+    contractEditor.extractChangedContractAddresses(inputEvents)
 
-    assert.deepStrictEqual(
-        editedEvents,
-        [decodedEventNotSNX, decodedEventSNXLegacy, correctedEventSNXLegacy, decodedEventSNXNew, correctedEventSNXNew]
-    )
+    // Test that input has not been modified in any way. We use JSON.stringify again to build same JSON structure.
+    assert.deepStrictEqual(JSON.stringify(inputEvents), inputEventsCopy)
   })
 
   it("test getPastEventsExactContracts correctly concatenates events", async function() {

--- a/test/erc20/extend_events.spec.js
+++ b/test/erc20/extend_events.spec.js
@@ -1,0 +1,99 @@
+const assert = require("assert")
+
+const {extendEventsWithPrimaryKey} = require("../../blockchains/erc20/lib/extend_events_key")
+const constants = require('../../blockchains/erc20/lib/constants')
+
+let inputEvent1 = {}
+let inputEvent2 = {}
+
+// The primary key algorithm for non overwritten events
+function calculatePrimaryKeyNonOverwrittenEvent(event) {
+  return event.blockNumber * constants.PRIMARY_KEY_MULTIPLIER + event.logIndex
+}
+
+function setExpectedEventPrimaryKey(event) {
+  event.primaryKey = calculatePrimaryKeyNonOverwrittenEvent(event)
+}
+
+
+describe('assignPrimaryKeys', function() {
+  beforeEach(function() {
+    inputEvent1 = {
+      address: '0x0D8775F648430679A709E98d2b0Cb6250d2887EF',
+      blockHash: '0x5e8eac3696797200b5ee04f3dc34b407c5921442686794eafcaf5076b837d7d4',
+      blockNumber: 3978360,
+      data: '0x000000000000000000000000000000000000000000000002b178b3e9acd86000',
+      logIndex: 8,
+      removed: false,
+      topics:
+      [ '0xb33527d2e0d30b7aece2c5e82927985866c1b75173d671c14f4457bf67aa6910',
+        '0x000000000000000000000000fbfa258b9028c7d4fc52ce28031469214d10daeb' ],
+      transactionHash: '0x62901c72c13cc56efe3180b1bc02b02c108ae0a68a76d594161c9a41d0ebcceb',
+      transactionIndex: 143,
+      transactionLogIndex: '0x0',
+      type: 'mined',
+      id: 'log_ff113a78'
+    }
+
+    inputEvent2 = {
+      address: '0xB8c77482e45F1F44dE1745F52C74426C631bDD52',
+      blockHash: '0xde18db2a41c7250412ff1297ad983173ccce8281c1d19498427a765e73cf9b98',
+      blockNumber: 3978360,
+      data: '0x00000000000000000000000000000000000000000034f086f3b33b6840000000',
+      logIndex: 31,
+      removed: false,
+      topics:
+      [ '0xf97a274face0b5517365ad396b1fdba6f68bd3135ef603e44272adba3af5a1e0',
+        '0x00000000000000000000000000c5e04176d95a286fcce0e68c683ca0bfec8454' ],
+      transactionHash: '0x72af0f55b97b033af3b6e6162463681730c6429d0bc9c6c6ae9ad595aa2fbc57',
+      transactionIndex: 70,
+      transactionLogIndex: '0x0',
+      type: 'mined',
+      id: 'log_caef200c'
+    }
+  });
+
+  it("assign primary keys, single event", async function() {
+    const expectedEvent = JSON.parse(JSON.stringify(inputEvent1))
+    extendEventsWithPrimaryKey([inputEvent1], [])
+
+    setExpectedEventPrimaryKey(expectedEvent)
+
+    assert.deepEqual(inputEvent1, expectedEvent)
+  })
+
+  it("assign primary keys, event list, overwritten are empty", async function() {
+    const expectedEvents = JSON.parse(JSON.stringify([inputEvent1, inputEvent2]))
+    extendEventsWithPrimaryKey([inputEvent1, inputEvent2], [])
+
+    setExpectedEventPrimaryKey(expectedEvents[0])
+    setExpectedEventPrimaryKey(expectedEvents[1])
+
+    assert.deepEqual([inputEvent1, inputEvent2], expectedEvents)
+  })
+
+  it("assign primary keys, event list, overwritten not empty", async function() {
+    const copyEvents = JSON.parse(JSON.stringify([inputEvent1, inputEvent2]))
+    const expectedEvents = JSON.parse(JSON.stringify([inputEvent1, inputEvent2]))
+    extendEventsWithPrimaryKey([inputEvent1, inputEvent2], copyEvents)
+
+    setExpectedEventPrimaryKey(expectedEvents[0])
+    setExpectedEventPrimaryKey(expectedEvents[1])
+
+    assert.deepEqual([inputEvent1, inputEvent2], expectedEvents)
+  })
+
+  it("assign primary keys, event list, check keys of overwritten", async function() {
+    const copyEvents = JSON.parse(JSON.stringify([inputEvent1, inputEvent2]))
+    const expectedEvents = JSON.parse(JSON.stringify(copyEvents))
+    extendEventsWithPrimaryKey([inputEvent1, inputEvent2], copyEvents)
+
+    const primaryKeyLastNonOverwritten = calculatePrimaryKeyNonOverwrittenEvent(inputEvent2)
+    // Primary keys of overwritten contracts start from last non-overwritten and increase by 1
+    expectedEvents[0].primaryKey = primaryKeyLastNonOverwritten + 1
+    expectedEvents[1].primaryKey = primaryKeyLastNonOverwritten + 2
+
+    assert.deepEqual(copyEvents, expectedEvents)
+  })
+})
+


### PR DESCRIPTION
With a previous PR:
https://github.com/santiment/san-chain-exporter/pull/41
we introduced a new mode of operation where we both extract events as they are and also duplicate some of them and replace the contract address, the so called 'contract migration'. However this new mode of operation introduced a bug related to the primary key generation. Since the duplicated events are identical to their source events - the primary key generation algorithm assigned them identical primary keys. This PR address this issue. The solution chosen is for the duplicate events to receive consecutive primary keys, after the last primary key used for a 'real' event.