### PR TITLE
Unify health check. Remove extra call to web3.

### DIFF
--- a/blockchains/cardano/cardano_worker.js
+++ b/blockchains/cardano/cardano_worker.js
@@ -50,22 +50,22 @@ class CardanoWorker extends BaseWorker {
         blockIndex
         fee
         hash
-  
+
         block {
           number
           epochNo
         }
-  
+
         inputs {
           address
           value
         }
-    
+
         outputs {
           address
           value
         }
-  
+
       }
     }`)
 
@@ -118,20 +118,6 @@ class CardanoWorker extends BaseWorker {
     this.lastPrimaryKey += transactions.length
 
     return transactions
-  }
-
-  healthcheckExportTimeout() {
-    const timeFromLastExport = Date.now() - this.lastExportTime
-    const isExportTimeoutExceeded = timeFromLastExport > constants.EXPORT_TIMEOUT_MLS
-    if (isExportTimeoutExceeded) {
-      return Promise.reject(`Time from the last export ${timeFromLastExport}ms exceeded limit  ${constants.EXPORT_TIMEOUT_MLS}ms.`)
-    } else {
-      return Promise.resolve()
-    }
-  }
-
-  healthcheck() {
-    return this.healthcheckExportTimeout()
   }
 }
 

--- a/blockchains/cardano/lib/constants.js
+++ b/blockchains/cardano/lib/constants.js
@@ -1,9 +1,7 @@
 const CONFIRMATIONS = parseInt(process.env.CONFIRMATIONS || "3")
-const EXPORT_TIMEOUT_MLS = parseInt(process.env.EXPORT_TIMEOUT_MLS || 1000 * 60 * 5)     // 5 minutes
 const LOOP_INTERVAL_CURRENT_MODE_SEC = parseInt(process.env.LOOP_INTERVAL_CURRENT_MODE_SEC || "30")
 
 module.exports = {
     CONFIRMATIONS,
-    EXPORT_TIMEOUT_MLS,
     LOOP_INTERVAL_CURRENT_MODE_SEC
 }

--- a/blockchains/erc20/erc20_worker.js
+++ b/blockchains/erc20/erc20_worker.js
@@ -68,21 +68,6 @@ class ERC20Worker extends BaseWorker {
     this.lastExportedBlock = toBlock
     return events.concat(overwritten_events)
   }
-
-  healthcheckExportTimeout() {
-    const timeFromLastExport = Date.now() - this.lastExportTime
-    const isExportTimeoutExceeded = timeFromLastExport > constants.EXPORT_TIMEOUT_MLS
-    if (isExportTimeoutExceeded) {
-      return Promise.reject(`Time from the last export ${timeFromLastExport}ms exceeded limit  ${constants.EXPORT_TIMEOUT_MLS}ms.`)
-    } else {
-      return Promise.resolve()
-    }
-  }
-
-  healthcheck() {
-    return this.web3.eth.getBlockNumber()
-    .then(this.healthcheckExportTimeout())
-  }
 }
 
 module.exports = {

--- a/blockchains/erc20/lib/constants.js
+++ b/blockchains/erc20/lib/constants.js
@@ -3,7 +3,6 @@ const CONFIRMATIONS = parseInt(process.env.CONFIRMATIONS || "3")
 // This multiplier is used to expand the space of the output primary keys.
 //This allows for the event indexes to be added to the primary key.
 const PRIMARY_KEY_MULTIPLIER = 10000
-const EXPORT_TIMEOUT_MLS = parseInt(process.env.EXPORT_TIMEOUT_MLS || 1000 * 60 * 5)     // 5 minutes
 // We support three modes of operation
 // "vanilla" - extract events as seen on the blockchain
 // "extract_exact_overwrite" - extract only specified list of contracts, overwrite contract names
@@ -26,7 +25,6 @@ module.exports = {
     BLOCK_INTERVAL,
     CONFIRMATIONS,
     PRIMARY_KEY_MULTIPLIER,
-    EXPORT_TIMEOUT_MLS,
     CONTRACT_MODE,
     PARITY_NODE,
     CONTRACT_MAPPING_FILE_PATH,

--- a/blockchains/eth/eth_worker.js
+++ b/blockchains/eth/eth_worker.js
@@ -197,21 +197,6 @@ class ETHWorker extends BaseWorker {
     this.lastConfirmedBlock = await this.web3.eth.getBlockNumber() - constants.CONFIRMATIONS
   }
 
-  healthcheckExportTimeout() {
-    const timeFromLastExport = Date.now() - this.lastExportTime
-    const isExportTimeoutExceeded = timeFromLastExport > constants.EXPORT_TIMEOUT_MLS
-    if (isExportTimeoutExceeded) {
-      return Promise.reject(`Time from the last export ${timeFromLastExport}ms exceeded limit  ${constants.EXPORT_TIMEOUT_MLS}ms.`)
-    } else {
-      return Promise.resolve()
-    }
-  }
-
-  healthcheck() {
-    return this.web3.eth.getBlockNumber()
-    .then(this.healthcheckExportTimeout())
-  }
-
 }
 
 module.exports = {

--- a/blockchains/eth/lib/constants.js
+++ b/blockchains/eth/lib/constants.js
@@ -1,13 +1,11 @@
 const BLOCK_INTERVAL = parseInt(process.env.BLOCK_INTERVAL || "100")
 const CONFIRMATIONS = parseInt(process.env.CONFIRMATIONS || "3")
-const EXPORT_TIMEOUT_MLS = parseInt(process.env.EXPORT_TIMEOUT_MLS || 1000 * 60 * 5)     // 5 minutes
 const PARITY_NODE = process.env.PARITY_URL || "http://localhost:8545/"
 const LOOP_INTERVAL_CURRENT_MODE_SEC = parseInt(process.env.LOOP_INTERVAL_CURRENT_MODE_SEC || "30")
 
 module.exports = {
     BLOCK_INTERVAL,
     CONFIRMATIONS,
-    EXPORT_TIMEOUT_MLS,
     PARITY_NODE,
     LOOP_INTERVAL_CURRENT_MODE_SEC
 }

--- a/blockchains/matic/lib/constants.js
+++ b/blockchains/matic/lib/constants.js
@@ -1,13 +1,11 @@
 const BLOCK_INTERVAL = parseInt(process.env.BLOCK_INTERVAL || "100")
 const CONFIRMATIONS = parseInt(process.env.CONFIRMATIONS || "3")
-const EXPORT_TIMEOUT_MLS = parseInt(process.env.EXPORT_TIMEOUT_MLS || 1000 * 60 * 5)     // 5 minutes
 const PARITY_NODE = process.env.PARITY_URL || "http://localhost:8545/"
 const LOOP_INTERVAL_CURRENT_MODE_SEC = parseInt(process.env.LOOP_INTERVAL_CURRENT_MODE_SEC || "30")
 
 module.exports = {
     BLOCK_INTERVAL,
     CONFIRMATIONS,
-    EXPORT_TIMEOUT_MLS,
     PARITY_NODE,
     LOOP_INTERVAL_CURRENT_MODE_SEC
 }

--- a/blockchains/matic/matic_worker.js
+++ b/blockchains/matic/matic_worker.js
@@ -59,22 +59,6 @@ class MaticWorker extends BaseWorker {
   async init() {
     this.lastConfirmedBlock = await this.web3.eth.getBlockNumber() - constants.CONFIRMATIONS
   }
-
-  healthcheckExportTimeout() {
-    const timeFromLastExport = Date.now() - this.lastExportTime
-    const isExportTimeoutExceeded = timeFromLastExport > constants.EXPORT_TIMEOUT_MLS
-    if (isExportTimeoutExceeded) {
-      return Promise.reject(`Time from the last export ${timeFromLastExport}ms exceeded limit  ${constants.EXPORT_TIMEOUT_MLS}ms.`)
-    } else {
-      return Promise.resolve()
-    }
-  }
-
-  healthcheck() {
-    return this.web3.eth.getBlockNumber()
-    .then(this.healthcheckExportTimeout())
-  }
-
 }
 
 module.exports = {

--- a/index.js
+++ b/index.js
@@ -65,6 +65,7 @@ class Main {
     }
     catch(ex) {
       console.error("Error in exporter work loop: ", ex)
+      throw ex
     }
   }
 

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,0 +1,5 @@
+const EXPORT_TIMEOUT_MLS = parseInt(process.env.EXPORT_TIMEOUT_MLS || 1000 * 60 * 5)     // 5 minutes
+
+module.exports = {
+    EXPORT_TIMEOUT_MLS
+}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "mocha --recursive --reporter spec",
-    "lint": "jslint '**/*.js'",
+    "lint": "eslint '**/*.js'",
     "start": "micro"
   },
   "repository": {


### PR DESCRIPTION
Move the common code for doing health check to the common `index.js` implementation. Also remove the sync call to `web3` on doing the health check. This is too fragile and serves no purpose. When Parity is overloaded this extra `web3` call can take too much time and fail the health check even though we are exporting blocks.