### PR TITLE
Change post-London fee logic so that all trx types burn fees

### DIFF
--- a/blockchains/eth/lib/constants.js
+++ b/blockchains/eth/lib/constants.js
@@ -3,11 +3,13 @@ const CONFIRMATIONS = parseInt(process.env.CONFIRMATIONS || "3")
 const PARITY_NODE = process.env.PARITY_URL || "http://localhost:8545/"
 const LOOP_INTERVAL_CURRENT_MODE_SEC = parseInt(process.env.LOOP_INTERVAL_CURRENT_MODE_SEC || "30")
 const BURN_ADDRESS = "burn"
+const LONDON_FORK_BLOCK = 12965001
 
 module.exports = {
     BLOCK_INTERVAL,
     CONFIRMATIONS,
     PARITY_NODE,
     LOOP_INTERVAL_CURRENT_MODE_SEC,
-    BURN_ADDRESS
+    BURN_ADDRESS,
+    LONDON_FORK_BLOCK
 }

--- a/blockchains/eth/lib/constants.js
+++ b/blockchains/eth/lib/constants.js
@@ -3,7 +3,7 @@ const CONFIRMATIONS = parseInt(process.env.CONFIRMATIONS || "3")
 const PARITY_NODE = process.env.PARITY_URL || "http://localhost:8545/"
 const LOOP_INTERVAL_CURRENT_MODE_SEC = parseInt(process.env.LOOP_INTERVAL_CURRENT_MODE_SEC || "30")
 const BURN_ADDRESS = "burn"
-const LONDON_FORK_BLOCK = 12965001
+const LONDON_FORK_BLOCK = 12965000
 
 module.exports = {
     BLOCK_INTERVAL,

--- a/blockchains/eth/lib/fees_decoder.js
+++ b/blockchains/eth/lib/fees_decoder.js
@@ -3,7 +3,6 @@ const constants = require('./constants')
 
 class FeesDecoder {
   constructor(web3, web3Wrapper) {
-    this.web3 = web3
     this.web3Wrapper = web3Wrapper
   }
 
@@ -12,7 +11,7 @@ class FeesDecoder {
       from: transaction.from,
       to: block.miner,
       value: computeGasExpense(this.web3Wrapper, transaction.gasPrice, receipts[transaction.hash].gasUsed),
-      valueExactBase36: computeGasExpenseBase36(this.web3, transaction.gasPrice, receipts[transaction.hash].gasUsed),
+      valueExactBase36: computeGasExpenseBase36(this.web3Wrapper, transaction.gasPrice, receipts[transaction.hash].gasUsed),
       blockNumber: this.web3Wrapper.parseHexToNumber(transaction.blockNumber),
       timestamp: this.web3Wrapper.parseHexToNumber(block.timestamp),
       transactionHash: transaction.hash,
@@ -20,35 +19,96 @@ class FeesDecoder {
     }]
   }
 
-  getPostLondonForkFees(transaction, block, receipts) {
-    const result = []
-    const maxPriorityFeePerGas = transaction['maxPriorityFeePerGas']
-
-    if (this.web3Wrapper.parseValue(maxPriorityFeePerGas) > 0) {
-      result.push({
-        from: transaction.from,
-        to: block.miner,
-        value: computeGasExpense(this.web3Wrapper, maxPriorityFeePerGas, receipts[transaction.hash].gasUsed),
-        valueExactBase36: computeGasExpenseBase36(this.web3, maxPriorityFeePerGas,
-          receipts[transaction.hash].gasUsed),
-        blockNumber: this.web3Wrapper.parseHexToNumber(transaction.blockNumber),
-        timestamp: this.web3Wrapper.parseHexToNumber(block.timestamp),
-        transactionHash: transaction.hash,
-        type: "fee"
-      })
-    }
-
+  pushBurntFee(transaction, block, receipts, result) {
     result.push({
       from: transaction.from,
       to: constants.BURN_ADDRESS,
       value: computeGasExpense(this.web3Wrapper, block.baseFeePerGas, receipts[transaction.hash].gasUsed),
-      valueExactBase36: computeGasExpenseBase36(this.web3, block.baseFeePerGas,
+      valueExactBase36: computeGasExpenseBase36(this.web3Wrapper, block.baseFeePerGas,
         receipts[transaction.hash].gasUsed),
       blockNumber: this.web3Wrapper.parseHexToNumber(transaction.blockNumber),
       timestamp: this.web3Wrapper.parseHexToNumber(block.timestamp),
       transactionHash: transaction.hash,
       type: "fee_burnt"
     })
+  }
+
+  pushType2MinerFee(transaction, block, receipts, result) {
+    /***
+     * An EIP1559 transaction always pays the base fee of the block it’s included in, and it pays a priority fee
+     * as priced by maxPriorityFeePerGas or, if the base fee per gas + maxPriorityFeePerGas exceeds maxFeePerGas,
+     * it pays a priority fee as priced by maxFeePerGas minus the base fee per gas.
+     *
+     * EIP1559 transactions must specify both maxPriorityFeePerGas and maxFeePerGas. They must not specify gasPrice.
+     *
+     * https://besu.hyperledger.org/en/stable/Concepts/Transactions/Transaction-Types/
+     */
+    const maxPriorityFeePerGas = this.web3Wrapper.parseValueToBN(transaction['maxPriorityFeePerGas'])
+    const maxFeePerGas = this.web3Wrapper.parseValueToBN(transaction['maxFeePerGas'])
+    const baseFeePerGas = this.web3Wrapper.parseValueToBN(block.baseFeePerGas)
+
+    const minerFeePerGas = baseFeePerGas.add(maxPriorityFeePerGas).gt(maxFeePerGas) ?
+    maxFeePerGas.sub(baseFeePerGas) : maxPriorityFeePerGas
+
+    if (minerFeePerGas > 0) {
+      result.push({
+        from: transaction.from,
+        to: block.miner,
+        value: computeGasExpense(this.web3Wrapper, minerFeePerGas, receipts[transaction.hash].gasUsed),
+        valueExactBase36: computeGasExpenseBase36(this.web3Wrapper, minerFeePerGas, receipts[transaction.hash].gasUsed),
+        blockNumber: this.web3Wrapper.parseHexToNumber(transaction.blockNumber),
+        timestamp: this.web3Wrapper.parseHexToNumber(block.timestamp),
+        transactionHash: transaction.hash,
+        type: "fee"
+      })
+    }
+  }
+
+/**
+ * Legacy Ethereum transactions will still work and be included in blocks, but they will not benefit directly
+ * from the new pricing system. This is due to the fact that upgrading from legacy transactions to new transactions
+ * results in the legacy transaction's gas_price entirely being consumed either by the base_fee_per_gas and the
+ * priority_fee_per_gas.
+ *
+ * https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1559.md
+ **/
+  pushPreType2MinerFeePostLondon(transaction, block, receipts, result) {
+    const tipMinerPerGas = transaction.gasPrice - block.baseFeePerGas
+      if (tipMinerPerGas > 0) {
+        result.push({
+          from: transaction.from,
+          to: block.miner,
+          value: computeGasExpense(this.web3Wrapper, tipMinerPerGas, receipts[transaction.hash].gasUsed),
+          valueExactBase36: computeGasExpenseBase36(this.web3Wrapper, tipMinerPerGas,
+            receipts[transaction.hash].gasUsed),
+          blockNumber: this.web3Wrapper.parseHexToNumber(transaction.blockNumber),
+          timestamp: this.web3Wrapper.parseHexToNumber(block.timestamp),
+          transactionHash: transaction.hash,
+          type: "fee"
+        })
+      }
+  }
+
+  pushFeeMinerPostLondon(transaction, block, receipts, result) {
+    if (this.web3Wrapper.parseHexToNumber(transaction.type) >= 2) {
+      this.pushType2MinerFee(transaction, block, receipts, result)
+    }
+    else {
+      this.pushPreType2MinerFeePostLondon(transaction, block, receipts, result)
+    }
+  }
+
+  getPostLondonForkFees(transaction, block, receipts) {
+    /**
+     * Determining the fees is a three-step process:
+     *
+     * 1. The base fee is deducted from the max fee, and is burned.
+     * 2. If there’s ETH left after the deduction, it is used to pay a tip to the miner, up to a maximum of the max priority fee decided by the user.
+     * 3. If there’s still ETH left after the tip, it is refunded to the transaction’s sender.
+     */
+    const result = []
+    this.pushBurntFee(transaction, block, receipts, result)
+    this.pushFeeMinerPostLondon(transaction, block, receipts, result)
 
     return result
   }
@@ -56,8 +116,9 @@ class FeesDecoder {
   getFeesFromTransactionsInBlock(block, receipts) {
     const result = []
     block.transactions.forEach((transaction) => {
+      const blockNumber = this.web3Wrapper.parseHexToNumber(block.number)
       const feeTransfers =
-        this.web3Wrapper.parseHexToNumber(transaction.type) == 2 ?
+        blockNumber >= constants.LONDON_FORK_BLOCK ?
         this.getPostLondonForkFees(transaction, block, receipts) :
         this.getPreLondonForkFees(transaction, block, receipts)
 

--- a/blockchains/eth/lib/util.js
+++ b/blockchains/eth/lib/util.js
@@ -19,11 +19,11 @@ function stableSort(array, sortFunc) {
 }
 
 function computeGasExpense (web3Wrapper, gasPrice, gasUsed) {
-  return web3Wrapper.parseValue(gasPrice) * web3Wrapper.parseValue(gasUsed)
+  return web3Wrapper.parseValueToBN(gasPrice) * web3Wrapper.parseValueToBN(gasUsed)
 }
 
-function computeGasExpenseBase36 (web3, gasPrice, gasUsed) {
-  return web3.utils.toBN(gasPrice).mul(web3.utils.toBN(gasUsed)).toString(36)
+function computeGasExpenseBase36 (web3Wrapper, gasPrice, gasUsed) {
+  return web3Wrapper.parseValueToBN(gasPrice).mul(web3Wrapper.parseValueToBN(gasUsed)).toString(36)
 }
 
 module.exports = {

--- a/blockchains/eth/lib/web3_wrapper.js
+++ b/blockchains/eth/lib/web3_wrapper.js
@@ -5,8 +5,8 @@ class Web3Wrapper {
         this.web3 = web3
     }
 
-    parseValueExactBase36(field) {
-        return this.web3.utils.toBN(field).toString(36)
+    parseValueToBN(field) {
+        return this.web3.utils.toBN(field)
     }
 
     parseHexToNumberString(field) {
@@ -26,7 +26,7 @@ class Web3Wrapper {
     }
 
     parseValueBase36(field) {
-        return this.parseValueExactBase36(field)
+        return this.parseValueToBN(field).toString(36)
     }
 
     parseTransactionPosition(field) {
@@ -38,7 +38,7 @@ class Web3Wrapper {
     }
 
     parseBalanceBase36(field) {
-        return this.parseValueExactBase36(field)
+        return this.parseValueBase36(field)
     }
 
     decodeTimestampFromBlock(block) {

--- a/test/eth/fees_decoder.spec.js
+++ b/test/eth/fees_decoder.spec.js
@@ -265,39 +265,6 @@ describe('Fees decoder test', function() {
       assert.deepStrictEqual(postLondonFees, expected)
     })
 
-    /**
-     * Test that the miner fee paid would be reduced due to maxFeePerGas.
-     */
-    it("test fees post London maxFeePerGas", async function () {
-      const postLondonFees = feesDecoder.getFeesFromTransactionsInBlock(
-        block_json_post_london_fee_reduced_by_maxFeePerGas,
-        turnReceiptsToMap(receipts_json_post_london_with_priority))
-
-      const expected =  [{
-          blockNumber: 13447057,
-          from: "0x8ae57a027c63fca8070d1bf38622321de8004c67",
-          timestamp: 1634631172,
-          to: "burn",
-          transactionHash: "0x1e53bf3951f6cb70461df500ec75ed5d88d73bd44d88ca7faabaa4b1e65aec98",
-          type: "fee_burnt",
-          value: 3653345337731778,
-          valueExactBase36: "zz03ofi5du"
-        },
-        {
-          from: '0x8ae57a027c63fca8070d1bf38622321de8004c67',
-          to: '0xea674fdde714fd979de3edf0f56aa9716b898ec8',
-          value: 954662268222,
-          valueExactBase36: "c6kd9kji",
-          blockNumber: 13447057,
-          timestamp: 1634631172,
-          transactionHash: '0x1e53bf3951f6cb70461df500ec75ed5d88d73bd44d88ca7faabaa4b1e65aec98',
-          type: 'fee'
-        }
-      ]
-
-      assert.deepStrictEqual(postLondonFees, expected)
-    })
-
     it("test old type fees post London", async function () {
       const postLondonFees = feesDecoder.getFeesFromTransactionsInBlock(block_json_post_london_old_tx_type,
         turnReceiptsToMap(receipts_json_post_london_old_tx_type))

--- a/test/eth/fees_decoder.spec.js
+++ b/test/eth/fees_decoder.spec.js
@@ -4,7 +4,11 @@ const Web3Wrapper = require('../../blockchains/eth/lib/web3_wrapper')
 const {FeesDecoder} = require('../../blockchains/eth/lib/fees_decoder')
 const constants = require('../../blockchains/eth/lib/constants')
 
-const block_json_post_london_no_priority = {
+/**
+ * A transaction for which there is zero 'maxPriorityFeePerGas' and also 'maxFeePerGas' - 'baseFeePerGas' = 0.
+ * This should produce no miner fee transfer.
+ */
+const block_json_post_london_zero_priority = {
   "baseFeePerGas": "0xba37423df",
   "gasLimit": "0x1caa85f",
   "gasUsed": "0x9041b5",
@@ -20,7 +24,7 @@ const block_json_post_london_no_priority = {
     "gas": "0x3d090",
     "gasPrice": "0xba37423df",
     "maxPriorityFeePerGas": "0x0",
-    "maxFeePerGas": "0x1a0a7c1eda",
+    "maxFeePerGas": "0xba37423df",
     "hash": "0xc8bebc11bbe703cdfb2a1a9599221baf4f19a1e20808866346791799d2dac7a9",
     "to": "0x48ee18b6dd7d10214be35ba540b606b3a2c44d7c",
     "transactionIndex": "0x0",
@@ -28,6 +32,36 @@ const block_json_post_london_no_priority = {
     "type": "0x2"
     }]
 }
+
+/**
+ * A transaction for which the miner fee is reduced by the value of 'maxFeePerGas'.
+ */
+ const block_json_post_london_fee_reduced_by_maxFeePerGas = {
+  "baseFeePerGas": "0xba37423df",
+  "gasLimit": "0x1caa85f",
+  "gasUsed": "0x9041b5",
+  "hash": "0x6b029d5ebe5ca9bc568cd8630bd0af3d6b2b7ebed39fb7a6127a9169017010bd",
+  "miner": "0xea674fdde714fd979de3edf0f56aa9716b898ec8",
+  "number": "0xcd2f91",
+  "timestamp": "0x616e7e04",
+  "totalDifficulty": "0x6ec3c4e96a280cc26b8",
+  "transactions": [
+  {
+    "blockHash": "0x6b029d5ebe5ca9bc568cd8630bd0af3d6b2b7ebed39fb7a6127a9169017010bd",
+    "blockNumber": "0xcd2f91",
+    "from": "0x8ae57a027c63fca8070d1bf38622321de8004c67",
+    "gas": "0x2a6af",
+    "gasPrice": "0xbdf0eeddf",
+    "maxPriorityFeePerGas": "0x3b9aca00",
+    "maxFeePerGas": "0xBA43B7400",
+    "hash": "0x1e53bf3951f6cb70461df500ec75ed5d88d73bd44d88ca7faabaa4b1e65aec98",
+    "to": "0x2f102e69cbce4938cf7fb27adb40fad097a13668",
+    "transactionIndex": "0xa4",
+    "value": "0x0",
+    "type": "0x2"
+  }]
+}
+
 
 const block_json_post_london_with_priority = {
   "baseFeePerGas": "0xba37423df",
@@ -54,6 +88,51 @@ const block_json_post_london_with_priority = {
     "type": "0x2"
   }
 ]}
+
+const block_json_post_london_old_tx_type = {
+  "baseFeePerGas": "0xf6e9b0a7f",
+  "hash": "0xc66d31320e1b56947efc0b3014950a1211063cd8cbf12399ebbc905d54bca00a",
+  "miner": "0xea674fdde714fd979de3edf0f56aa9716b898ec8",
+  "number": "0xcb3928",
+  "timestamp": "0x6153e50a",
+  "transactions": [{
+    "blockHash": "0xc66d31320e1b56947efc0b3014950a1211063cd8cbf12399ebbc905d54bca00a",
+    "blockNumber": "0xcb3928",
+    "from": "0xddfabcdc4d8ffc6d5beaf154f18b778f892a0740",
+    "gas": "0x5208",
+    "gasPrice": "0xfe5d09e7f",
+    "maxPriorityFeePerGas": "0x77359400",
+    "maxFeePerGas": "0x1e80355e00",
+    "hash": "0xec5b5841e0a425bf69553a0ccecfa58b053a63e30f5fbdd9ecbdee5e9fb0666c",
+    "input": "0x",
+    "nonce": "0x1f9ac2",
+    "to": "0x9fae918aeb96e876e25ee6975bcc2976cf48f595",
+    "transactionIndex": "0x61",
+    "value": "0x765ae822ac7f2000",
+    "type": "0x2",
+    "chainId": "0x1",
+    "v": "0x0",
+    "r": "0xeb6780fe250ffa23c04435a80c2a65bcc8a4255d099fc13bcf613d904c7e4546",
+    "s": "0x3f64aaa4de82769c74d30c4f8facba39b61555eb667e9211122ae9ca320df39c"
+  }]
+}
+
+const receipts_json_post_london_old_tx_type = [{
+  "blockHash": "0xc66d31320e1b56947efc0b3014950a1211063cd8cbf12399ebbc905d54bca00a",
+  "blockNumber": "0xcb3928",
+  "contractAddress": null,
+  "cumulativeGasUsed": "0x3880ad",
+  "effectiveGasPrice": "0xfe5d09e7f",
+  "from": "0xddfabcdc4d8ffc6d5beaf154f18b778f892a0740",
+  "gasUsed": "0x5208",
+  "logs": [],
+  "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+  "status": "0x1",
+  "to": "0x9fae918aeb96e876e25ee6975bcc2976cf48f595",
+  "transactionHash": "0xec5b5841e0a425bf69553a0ccecfa58b053a63e30f5fbdd9ecbdee5e9fb0666c",
+  "transactionIndex": "0x61",
+  "type": "0x2"
+}]
 
 const receipts_json_post_london_no_priority = [{
   "blockHash": "0x6b029d5ebe5ca9bc568cd8630bd0af3d6b2b7ebed39fb7a6127a9169017010bd",
@@ -138,8 +217,8 @@ describe('Fees decoder test', function() {
       feesDecoder = new FeesDecoder(web3, web3Wrapper)
     })
 
-    it("test fees post London no priority", async function () {
-        const postLondonFees = feesDecoder.getFeesFromTransactionsInBlock(block_json_post_london_no_priority,
+    it("test fees post London zero priority", async function () {
+        const postLondonFees = feesDecoder.getFeesFromTransactionsInBlock(block_json_post_london_zero_priority,
           turnReceiptsToMap(receipts_json_post_london_no_priority))
 
         const expected =  [{
@@ -162,16 +241,6 @@ describe('Fees decoder test', function() {
         turnReceiptsToMap(receipts_json_post_london_with_priority))
 
       const expected =  [{
-          from: '0x8ae57a027c63fca8070d1bf38622321de8004c67',
-          to: '0xea674fdde714fd979de3edf0f56aa9716b898ec8',
-          value: 73086000000000,
-          valueExactBase36: 'pwn8tdiio',
-          blockNumber: 13447057,
-          timestamp: 1634631172,
-          transactionHash: '0x1e53bf3951f6cb70461df500ec75ed5d88d73bd44d88ca7faabaa4b1e65aec98',
-          type: 'fee'
-        },
-        {
           blockNumber: 13447057,
           from: "0x8ae57a027c63fca8070d1bf38622321de8004c67",
           timestamp: 1634631172,
@@ -180,11 +249,83 @@ describe('Fees decoder test', function() {
           type: "fee_burnt",
           value: 3653345337731778,
           valueExactBase36: "zz03ofi5du"
+        },
+        {
+          from: '0x8ae57a027c63fca8070d1bf38622321de8004c67',
+          to: '0xea674fdde714fd979de3edf0f56aa9716b898ec8',
+          value: 73086000000000,
+          valueExactBase36: 'pwn8tdiio',
+          blockNumber: 13447057,
+          timestamp: 1634631172,
+          transactionHash: '0x1e53bf3951f6cb70461df500ec75ed5d88d73bd44d88ca7faabaa4b1e65aec98',
+          type: 'fee'
         }
       ]
 
       assert.deepStrictEqual(postLondonFees, expected)
-  })
+    })
+
+    /**
+     * Test that the miner fee paid would be reduced due to maxFeePerGas.
+     */
+    it("test fees post London maxFeePerGas", async function () {
+      const postLondonFees = feesDecoder.getFeesFromTransactionsInBlock(
+        block_json_post_london_fee_reduced_by_maxFeePerGas,
+        turnReceiptsToMap(receipts_json_post_london_with_priority))
+
+      const expected =  [{
+          blockNumber: 13447057,
+          from: "0x8ae57a027c63fca8070d1bf38622321de8004c67",
+          timestamp: 1634631172,
+          to: "burn",
+          transactionHash: "0x1e53bf3951f6cb70461df500ec75ed5d88d73bd44d88ca7faabaa4b1e65aec98",
+          type: "fee_burnt",
+          value: 3653345337731778,
+          valueExactBase36: "zz03ofi5du"
+        },
+        {
+          from: '0x8ae57a027c63fca8070d1bf38622321de8004c67',
+          to: '0xea674fdde714fd979de3edf0f56aa9716b898ec8',
+          value: 954662268222,
+          valueExactBase36: "c6kd9kji",
+          blockNumber: 13447057,
+          timestamp: 1634631172,
+          transactionHash: '0x1e53bf3951f6cb70461df500ec75ed5d88d73bd44d88ca7faabaa4b1e65aec98',
+          type: 'fee'
+        }
+      ]
+
+      assert.deepStrictEqual(postLondonFees, expected)
+    })
+
+    it("test old type fees post London", async function () {
+      const postLondonFees = feesDecoder.getFeesFromTransactionsInBlock(block_json_post_london_old_tx_type,
+        turnReceiptsToMap(receipts_json_post_london_old_tx_type))
+
+      const expected =  [{
+          blockNumber: 13318440 ,
+          from: "0xddfabcdc4d8ffc6d5beaf154f18b778f892a0740",
+          timestamp: 1632888074,
+          to: "burn",
+          transactionHash: "0xec5b5841e0a425bf69553a0ccecfa58b053a63e30f5fbdd9ecbdee5e9fb0666c",
+          type: "fee_burnt",
+          value:  1391883443307000,
+          valueExactBase36: "dpdqfcs260"
+        },
+        {
+          from: '0xddfabcdc4d8ffc6d5beaf154f18b778f892a0740',
+          to: '0xea674fdde714fd979de3edf0f56aa9716b898ec8',
+          value: 42000000000000,
+          valueExactBase36: 'evyj7lbeo',
+          blockNumber: 13318440,
+          timestamp: 1632888074,
+          transactionHash: '0xec5b5841e0a425bf69553a0ccecfa58b053a63e30f5fbdd9ecbdee5e9fb0666c',
+          type: 'fee'
+        }
+      ]
+
+      assert.deepStrictEqual(postLondonFees, expected)
+    })
 
     it("test fees pre London", async function () {
       const preLondonFees = feesDecoder.getFeesFromTransactionsInBlock(block_json_pre_london,


### PR DESCRIPTION
A PR to fix the fee burning logic.
1. Even old style transactions burn the base fee after the London fork.
2. For the new type 2 transactions check if maxFeePerGas is not reducing the fee paid.