### PR TITLE
Fix for last block in Cardano query not full

### DIFF
--- a/blockchains/cardano/cardano_worker.js
+++ b/blockchains/cardano/cardano_worker.js
@@ -2,7 +2,6 @@
 "use strict";
 const got = require('got');
 const uuidv1 = require('uuid/v1')
-const { logger } = require('../../lib/logger')
 const BaseWorker = require("../../lib/worker_base")
 const constants = require("./lib/constants")
 const util = require("./lib/util")

--- a/blockchains/cardano/lib/util.js
+++ b/blockchains/cardano/lib/util.js
@@ -1,4 +1,6 @@
-  /**
+const { logger } = require('../../../lib/logger')
+
+/**
    * It is expected that transactions for the last included in the batch block are not complete.
    * We discard the non completed block and would re-try it on next iteration.
    */
@@ -15,6 +17,7 @@
           Block number is ${lastBlockNumber} it has ${transactions[0].block.transactionsCount} but only
           ${transactions.length - 1} were extracted.`)
       }
+      logger.debug("Removing ", transactions.length - index, " transactions from partial block ", lastBlockNumber)
       return transactions.slice(0, index + 1)
     }
 

--- a/blockchains/cardano/lib/util.js
+++ b/blockchains/cardano/lib/util.js
@@ -1,0 +1,49 @@
+  /**
+   * It is expected that transactions for the last included in the batch block are not complete.
+   * We discard the non completed block and would re-try it on next iteration.
+   */
+   function discardNotCompletedBlock(transactions) {
+    const lastBlockNumber = transactions[transactions.length - 1].block.number
+    let index = transactions.length - 2
+    while (index >= 0 && transactions[index].block.number == lastBlockNumber) {
+      --index
+    }
+
+    if (transactions[index + 1].block.transactionsCount != transactions.length - index - 1) {
+      if (index < 0) {
+        throw new Error(`Single extracted block is partial. Exporter would not be able to progress.
+          Block number is ${lastBlockNumber} it has ${transactions[0].block.transactionsCount} but only
+          ${transactions.length - 1} were extracted.`)
+      }
+      return transactions.slice(0, index + 1)
+    }
+
+    return transactions
+  }
+
+  function verifyAllBlocksComplete(transactions) {
+    let lastBlockNumber = transactions[0].block.number
+    let transactionsInBlock = 1
+
+    for (let i = 1; i < transactions.length; i++) {
+      if (transactions[i].block.number != lastBlockNumber) {
+        // Check that all transactions are extracted
+        if (transactionsInBlock != transactions[i-1].block.transactionsCount) {
+           throw new Error(`The block ${lastBlockNumber} has ${transactions[i-1].block.transactionsCount}
+            transactions but we extracted ${transactionsInBlock} transactions`)
+        }
+        transactionsInBlock = 0
+        lastBlockNumber = transactions[i].block.number
+      }
+      ++transactionsInBlock
+    }
+
+    const expectedTrxInLastBlock = transactions[transactions.length - 1].block.transactionsCount
+    if (expectedTrxInLastBlock != transactionsInBlock) {
+         throw new Error(`The block ${lastBlockNumber} has ${expectedTrxInLastBlock}
+          transactions but we extracted ${transactionsInBlock} transactions`)
+      }
+  }
+module.exports = {
+  discardNotCompletedBlock, verifyAllBlocksComplete
+}

--- a/test/cardano/util.spec.js
+++ b/test/cardano/util.spec.js
@@ -1,0 +1,118 @@
+const assert = require("assert")
+
+const util = require(`../../blockchains/cardano/lib/util`)
+const constants = require("../../blockchains/cardano/lib/constants");
+
+function getTransactionsPartialLastBlock() {
+  return [
+         {
+      "includedAt": "2017-12-06T08:55:31Z",
+      "blockIndex": 1,
+      "fee": 194933,
+      "hash": "c56e8d96a91163bdb265191980dfe330a54777ba052222ce4aebd7483119ae6c",
+      "block": {
+        "number": 1,
+        "epochNo": 14,
+        "transactionsCount": 2
+      },
+      "inputs": [],
+      "outputs": []
+    },
+    {
+      "includedAt": "2017-12-06T08:55:31Z",
+      "blockIndex": 0,
+      "fee": 186803,
+      "hash": "9403cb2fde3573dc4f72b5b2249fe74e28bcbb039e51689535834c73e6aa3b64",
+      "block": {
+        "number": 1,
+        "epochNo": 14,
+        "transactionsCount": 2
+      },
+      "inputs": [],
+      "outputs": []
+    },
+    {
+      "includedAt": "2017-12-06T08:58:11Z",
+      "blockIndex": 1,
+      "fee": 171070,
+      "hash": "1413633eb460e7657ee606eeca43a7b37e7e97aeafc406056e8d226edfc299d4",
+      "block": {
+        "number": 2,
+        "epochNo": 14,
+        "transactionsCount": 2
+      },
+      "inputs": [],
+      "outputs": []
+    }
+  ]
+}
+
+function getTransactionsOnePartialBlock() {
+  return [{
+      "includedAt": "2017-12-06T08:58:11Z",
+      "blockIndex": 1,
+      "fee": 171070,
+      "hash": "1413633eb460e7657ee606eeca43a7b37e7e97aeafc406056e8d226edfc299d4",
+      "block": {
+        "number": 2,
+        "epochNo": 14,
+        "transactionsCount": 2
+      },
+      "inputs": [],
+      "outputs": []
+    }
+  ]
+}
+
+function getTransactionsFullBlock() {
+  return [{
+      "includedAt": "2017-12-06T08:58:11Z",
+      "blockIndex": 1,
+      "fee": 171070,
+      "hash": "1413633eb460e7657ee606eeca43a7b37e7e97aeafc406056e8d226edfc299d4",
+      "block": {
+        "number": 2,
+        "epochNo": 14,
+        "transactionsCount": 1
+      },
+      "inputs": [],
+      "outputs": []
+    }
+  ]
+}
+
+describe('discardNotCompletedBlock Test', function() {
+  it("test partial last block discarded", async function() {
+    const transactions = getTransactionsPartialLastBlock()
+    const result = util.discardNotCompletedBlock(transactions)
+    assert.deepStrictEqual(result, transactions.slice(0, 2))
+  })
+
+  it("test one partial block exception", async function() {
+    const transactions = getTransactionsOnePartialBlock()
+    assert.throws(function() {util.discardNotCompletedBlock(transactions)}, Error)
+  })
+
+  it("test full block is not altered", async function() {
+    const transactions = getTransactionsFullBlock()
+    const result = util.discardNotCompletedBlock(transactions)
+    assert.deepStrictEqual(result, transactions)
+  })
+})
+
+describe('verifyAllBlocksComplete Test', function() {
+  it("test throw on partial last block", async function() {
+    const transactions = getTransactionsPartialLastBlock()
+    assert.throws(function() {util.verifyAllBlocksComplete(transactions)}, Error)
+  })
+
+  it("test throw on partial single block", async function() {
+    const transactions = getTransactionsOnePartialBlock()
+    assert.throws(function() {util.verifyAllBlocksComplete(transactions)}, Error)
+  })
+
+  it("test verify passes on full block", async function() {
+    const transactions = getTransactionsFullBlock()
+    util.verifyAllBlocksComplete(transactions)
+  })
+})

--- a/test/cardano/worker.spec.js
+++ b/test/cardano/worker.spec.js
@@ -5,14 +5,15 @@ const constants = require("../../blockchains/cardano/lib/constants");
 
 function getParsedTransactions() {
   return [
-    {
+         {
       "includedAt": "2017-12-06T08:55:31Z",
       "blockIndex": 1,
       "fee": 194933,
       "hash": "c56e8d96a91163bdb265191980dfe330a54777ba052222ce4aebd7483119ae6c",
       "block": {
         "number": 317330,
-        "epochNo": 14
+        "epochNo": 14,
+        "transactionsCount": 2
       },
       "inputs": [
         {
@@ -50,7 +51,8 @@ function getParsedTransactions() {
       "hash": "9403cb2fde3573dc4f72b5b2249fe74e28bcbb039e51689535834c73e6aa3b64",
       "block": {
         "number": 317330,
-        "epochNo": 14
+        "epochNo": 14,
+        "transactionsCount": 2
       },
       "inputs": [
         {
@@ -84,7 +86,8 @@ function getParsedTransactions() {
       "hash": "1413633eb460e7657ee606eeca43a7b37e7e97aeafc406056e8d226edfc299d4",
       "block": {
         "number": 317338,
-        "epochNo": 14
+        "epochNo": 14,
+        "transactionsCount": 1
       },
       "inputs": [
         {


### PR DESCRIPTION
Fix for partial blocks in the cardano exporter.

The way the exporter fetches blocks - the last block may remain partial. We need to consider this and re-fetch it as a first block in the next iteration.