### PR TITLE
Disable timestamp manager by default

### DIFF
--- a/blockchains/erc20/lib/constants.js
+++ b/blockchains/erc20/lib/constants.js
@@ -12,6 +12,7 @@ const CONTRACT_MODE = process.env.CONTRACT_MODE || "vanilla"
 const PARITY_NODE = process.env.PARITY_URL || "http://localhost:8545/"
 const CONTRACT_MAPPING_FILE_PATH = "./contract_mapping/contract_mapping.json"
 const LOOP_INTERVAL_CURRENT_MODE_SEC = parseInt(process.env.LOOP_INTERVAL_CURRENT_MODE_SEC || "30")
+const USE_TIMESTAMP_MANAGER = parseInt(process.env.USE_TIMESTAMP_MANAGER || "0")
 
 function checkEnvVariables() {
     if (!CONTRACT_MODES_SUPPORTED.includes(CONTRACT_MODE)) {
@@ -28,5 +29,6 @@ module.exports = {
     CONTRACT_MODE,
     PARITY_NODE,
     CONTRACT_MAPPING_FILE_PATH,
-    LOOP_INTERVAL_CURRENT_MODE_SEC
+    LOOP_INTERVAL_CURRENT_MODE_SEC,
+    USE_TIMESTAMP_MANAGER
 }

--- a/blockchains/erc20/lib/fetch_events.js
+++ b/blockchains/erc20/lib/fetch_events.js
@@ -13,6 +13,8 @@ const BNB_contract = "0xb8c77482e45f1f44de1745f52c74426c631bdd52"
 const QNT_contract = "0x4a220e6096b25eadb88358cb44068a3248254675"
 const WETH_contract = "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
 
+const constants = require('./constants')
+
 
 let timestampsManager = null
 
@@ -22,7 +24,13 @@ function setGlobalTimestampManager(exporter) {
 }
 
 async function getBlockTimestamp(web3, blockNumber) {
-  return await timestampsManager.getBlockTimestamp(web3, blockNumber)
+  if (constants.USE_TIMESTAMP_MANAGER) {
+    return await timestampsManager.getBlockTimestamp(web3, blockNumber)
+  }
+  else {
+    return await timestampsManager.getTimestampFromNode(web3, blockNumber)
+  }
+
 }
 
 async function decodeEventBasicInfo(web3, event, blockTimestamps) {


### PR DESCRIPTION
Disable by default the Timestamp manager.

The timestamp correction implementation which we introduce as a hot fix in previous [PR](https://github.com/santiment/san-chain-exporter/pull/54) does not work correctly for all modes of operation. More precisely the 'exact' mode of operation where we get events for particular contracts, results in queries for block numbers out of order. For the time being made the functionality configurable and enable it only if needed.