### PR TITLE
Allow for one block gap in cardano export

### DIFF
--- a/blockchains/cardano/cardano_worker.js
+++ b/blockchains/cardano/cardano_worker.js
@@ -82,8 +82,9 @@ class CardanoWorker extends BaseWorker {
   }
 
   async work() {
-    if (this.lastConfirmedBlock == this.lastExportedBlock) {
+    if (this.lastExportedBlock >= this.lastConfirmedBlock - 1) {
       // We are up to date with the blockchain (aka 'current mode'). Sleep longer after finishing this loop.
+      // The last confirmed block may be partial and would not be exported. Allow for one block gap.
       this.sleepTimeMsec = constants.LOOP_INTERVAL_CURRENT_MODE_SEC * 1000;
 
       // On the previous cycle we closed the gap to the head of the blockchain.


### PR DESCRIPTION
When considering if we should sleep longer (aka 'current mode') allow for one block gap.

Before we considered to be in 'current' mode when the last block we have exported is the same as the last block that the Node reports:
`reportsthis.lastConfirmedBlock == this.lastExportedBlock`
However the node may report that last block is N, but the block may not be completed, so the condition would not hold. Instead we are changing the condition to this:
`this.lastExportedBlock >= this.lastConfirmedBlock - 1`
allowing for one block gap.
