### PR TITLE
Init TimestampManager for MaticExporter

### DIFF
--- a/blockchains/matic/matic_worker.js
+++ b/blockchains/matic/matic_worker.js
@@ -6,6 +6,7 @@ const BaseWorker = require('../../lib/worker_base')
 const Web3Wrapper = require('../eth/lib/web3_wrapper')
 const { extendEventsWithPrimaryKey } = require('../erc20/lib/extend_events_key')
 const { getPastEvents } = require('./lib/fetch_events')
+const { setGlobalTimestampManager } = require('../erc20/lib/fetch_events')
 
 
 class MaticWorker extends BaseWorker {
@@ -56,8 +57,9 @@ class MaticWorker extends BaseWorker {
 
   }
 
-  async init() {
+  async init(exporter) {
     this.lastConfirmedBlock = await this.web3.eth.getBlockNumber() - constants.CONFIRMATIONS
+    setGlobalTimestampManager(exporter)
   }
 }
 


### PR DESCRIPTION
A previous PR introduced a TimestampManager and initilazied it for ERC20 Worker. Howerver it was not initialized for Matic and since it reuses part of the erc20 code, this broke it.