### PR TITLE
Increase the number of confirmations for matic

### DIFF
--- a/blockchains/matic/lib/constants.js
+++ b/blockchains/matic/lib/constants.js
@@ -1,5 +1,5 @@
 const BLOCK_INTERVAL = parseInt(process.env.BLOCK_INTERVAL || "100")
-const CONFIRMATIONS = parseInt(process.env.CONFIRMATIONS || "3")
+const CONFIRMATIONS = parseInt(process.env.CONFIRMATIONS || "15")
 const PARITY_NODE = process.env.PARITY_URL || "http://localhost:8545/"
 const LOOP_INTERVAL_CURRENT_MODE_SEC = parseInt(process.env.LOOP_INTERVAL_CURRENT_MODE_SEC || "30")
 


### PR DESCRIPTION
We are missing some polygon erc20 transfers and receipts. Could be due to too low confirmations