### PR TITLE
Switch back to using mainstream node-rdkafka

### DIFF
--- a/e2e/producer-transaction.spec.js
+++ b/e2e/producer-transaction.spec.js
@@ -8,7 +8,7 @@
  */
 
 const { Exporter } = require('san-exporter')
-const Kafka = require("@santiment-network/node-rdkafka")
+const Kafka = require("node-rdkafka")
 const {storeEvents} = require('../lib/store_events')
 const KAFKA_URL = process.env.KAFKA_URL || "localhost:9092";
 

--- a/lib/kafka_storage.js
+++ b/lib/kafka_storage.js
@@ -1,4 +1,4 @@
-const Kafka = require("@santiment-network/node-rdkafka");
+const Kafka = require("node-rdkafka");
 const zk = require("node-zookeeper-client-async");
 const { logger } = require('./logger')
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,13 +8,13 @@
       "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
-        "@santiment-network/node-rdkafka": "2.10.12",
         "bignumber.js": "^9.0.0",
         "blockchain-utils": "git+https://github.com/santiment/blockchain-utils.git",
         "got": "^11.8.2",
         "jayson": "^3.5.2",
         "micro": "^9.3.4",
         "node-json-logger": "^0.0.17",
+        "node-rdkafka": "2.12.0",
         "node-zookeeper-client-async": "^1.0.0",
         "prom-client": "^13.1.0",
         "web3": "^1.2.11"
@@ -538,19 +538,6 @@
         "@ethersproject/logger": "^5.1.0",
         "@ethersproject/properties": "^5.1.0",
         "@ethersproject/strings": "^5.1.0"
-      }
-    },
-    "node_modules/@santiment-network/node-rdkafka": {
-      "version": "2.10.12",
-      "resolved": "https://registry.npmjs.org/@santiment-network/node-rdkafka/-/node-rdkafka-2.10.12.tgz",
-      "integrity": "sha512-eW+gcvBaTOjYATgVKVA9QgWqI37m8TDe3AYwMtXjWeZtTPqiOdffzu+v7itbNM+FAjVlgwvxJrtgGUYmI+gxew==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "bindings": "^1.3.1",
-        "nan": "^2.14.0"
-      },
-      "engines": {
-        "node": ">=6.0.0"
       }
     },
     "node_modules/@sindresorhus/is": {
@@ -4192,6 +4179,19 @@
         "moment-timezone": "^0.5.33"
       }
     },
+    "node_modules/node-rdkafka": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/node-rdkafka/-/node-rdkafka-2.12.0.tgz",
+      "integrity": "sha512-Wda7AQP+Bo8AhJDSAWTxSD8CsaJnirM+2whlKKP0mOO/I3iz9yoq/JQ2k1DGQ3BSEwXmg8adK064+ThjvCuOpw==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "bindings": "^1.3.1",
+        "nan": "^2.14.0"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/node-zookeeper-client": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/node-zookeeper-client/-/node-zookeeper-client-0.2.3.tgz",
@@ -7445,15 +7445,6 @@
         "@ethersproject/strings": "^5.1.0"
       }
     },
-    "@santiment-network/node-rdkafka": {
-      "version": "2.10.12",
-      "resolved": "https://registry.npmjs.org/@santiment-network/node-rdkafka/-/node-rdkafka-2.10.12.tgz",
-      "integrity": "sha512-eW+gcvBaTOjYATgVKVA9QgWqI37m8TDe3AYwMtXjWeZtTPqiOdffzu+v7itbNM+FAjVlgwvxJrtgGUYmI+gxew==",
-      "requires": {
-        "bindings": "^1.3.1",
-        "nan": "^2.14.0"
-      }
-    },
     "@sindresorhus/is": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.0.1.tgz",
@@ -10354,6 +10345,15 @@
       "integrity": "sha512-DTkKjFK9DDpXUxINPPJTfCrqlzgqBu3m2J2IJRoZBSz9x1Ns0t09SgZg8cdz7leUHxMb2pMmlpWjH0/NqpJsCA==",
       "requires": {
         "moment-timezone": "^0.5.33"
+      }
+    },
+    "node-rdkafka": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/node-rdkafka/-/node-rdkafka-2.12.0.tgz",
+      "integrity": "sha512-Wda7AQP+Bo8AhJDSAWTxSD8CsaJnirM+2whlKKP0mOO/I3iz9yoq/JQ2k1DGQ3BSEwXmg8adK064+ThjvCuOpw==",
+      "requires": {
+        "bindings": "^1.3.1",
+        "nan": "^2.14.0"
       }
     },
     "node-zookeeper-client": {

--- a/package.json
+++ b/package.json
@@ -19,13 +19,13 @@
   },
   "homepage": "https://github.com/santiment/erc20_transfers_exporter#readme",
   "dependencies": {
-    "@santiment-network/node-rdkafka": "2.10.12",
     "bignumber.js": "^9.0.0",
     "blockchain-utils": "git+https://github.com/santiment/blockchain-utils.git",
     "got": "^11.8.2",
     "jayson": "^3.5.2",
     "micro": "^9.3.4",
     "node-json-logger": "^0.0.17",
+    "node-rdkafka": "2.12.0",
     "node-zookeeper-client-async": "^1.0.0",
     "prom-client": "^13.1.0",
     "web3": "^1.2.11"


### PR DESCRIPTION
In this PR we restore to using the dependency node-rdkafka from main package. We used to install from a custom npm package due to missing features in the mainstream.