### PR TITLE
Wrap work with node-rdkafka callbacks in Promise

### DIFF
--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -27,6 +27,7 @@ services:
       KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
       KAFKA_DEFAULT_REPLICATION_FACTOR: 1
       KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      KAFKA_AUTO_CREATE_TOPICS_ENABLE: 'true'
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     logging:

--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ class Main {
   async init() {
     this.exporter = new Exporter(EXPORTER_NAME, true)
     await this.exporter.connect()
-    this.exporter.initTransactions()
+    await this.exporter.initTransactions()
     await this.initLastProcessedBlock()
     await this.setWorker()
     metrics.startCollection()

--- a/lib/kafka_storage.js
+++ b/lib/kafka_storage.js
@@ -257,17 +257,60 @@ exports.Exporter = class {
     });
   }
 
-  initTransactions() {
-    return this.producer.initTransactions(TRANSACTIONS_TIMEOUT_MS);
+  async initTransactions() {
+    const promise = new Promise((resolve, reject) => {
+      this.producer.initTransactions(TRANSACTIONS_TIMEOUT_MS, (err) => {
+        if (err) {
+            return reject(err);
+        }
+
+        resolve();
+      });
+    })
+
+    await promise
   }
-  beginTransaction() {
-    return this.producer.beginTransaction();
+
+  async beginTransaction() {
+    const promise = new Promise((resolve, reject) => {
+      this.producer.beginTransaction((err) => {
+        if (err) {
+          return reject(err);
+        }
+
+        resolve();
+      })
+    })
+
+    await promise
   }
-  commitTransaction() {
-    return this.producer.commitTransaction(TRANSACTIONS_TIMEOUT_MS);
+
+  async commitTransaction() {
+    const promise = new Promise((resolve, reject) => {
+      this.producer.commitTransaction(TRANSACTIONS_TIMEOUT_MS, (err) => {
+        if (err) {
+            return reject(err);
+        }
+
+        resolve();
+      });
+    })
+
+    await promise
   }
-  abortTransaction() {
-    return this.producer.abortTransaction(TRANSACTIONS_TIMEOUT_MS);
+
+  async abortTransaction() {
+    const promise = new Promise((resolve, reject) => {
+      this.producer.abortTransactions(TRANSACTIONS_TIMEOUT_MS, (err) => {
+        if (err) {
+            return reject(err);
+        }
+
+        resolve();
+      });
+    })
+
+    await promise
   }
 
 };

--- a/lib/store_events.js
+++ b/lib/store_events.js
@@ -3,7 +3,7 @@
 const { logger } = require('./logger')
 
 async function storeEvents(exporter, events) {
-  exporter.beginTransaction();
+  await exporter.beginTransaction();
 
   try {
     await exporter.sendDataWithKey(events, "primaryKey")
@@ -13,7 +13,7 @@ async function storeEvents(exporter, events) {
     throw exception;
   }
 
-  exporter.commitTransaction();
+  await exporter.commitTransaction();
 }
 
 module.exports = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "san-chain-exporter",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "MIT",
       "dependencies": {
         "bignumber.js": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "san-chain-exporter",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Exporter of all transfer events for a blockchain",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
In this PR:
* Latest version of node-rdkafka requires callbacks to be specified, making the functions async.
* However for our use case we want to treat them as sync functions. We do not want to proceed before the action is complete.
* So we wrap the async call into a promise and wait for it to get resolved.
* Some code and test fixes to comply with the code change.