### PR TITLE
Cardano genesis transfers

### DIFF
--- a/blockchains/cardano/cardano_worker.js
+++ b/blockchains/cardano/cardano_worker.js
@@ -66,8 +66,6 @@ class CardanoWorker extends BaseWorker {
             address
             value
           }
-
-
         }
       }
     `)

--- a/blockchains/cardano/cardano_worker.js
+++ b/blockchains/cardano/cardano_worker.js
@@ -79,6 +79,18 @@ class CardanoWorker extends BaseWorker {
     return response.data.transactions;
   }
 
+  // Genesis transfers have block number set to 'null'. For our computation purposes we need some block number.
+  // We set it to 0.
+  setBlockZeroForGenesisTransfers(transactions) {
+    transactions.forEach(transaction => {
+      if (transaction.block.number != null) {
+        throw new Error(`Unexpected block number ${transaction.block.number} for genesis transaction
+        ${transaction.hash}`)
+      }
+      transaction.block.number = 0
+    })
+  }
+
   async getTransactions(blockNumber) {
     const response = await this.sendRequest(`
     {
@@ -159,6 +171,7 @@ class CardanoWorker extends BaseWorker {
       if (transactions.length == 0) {
         throw new Error('Error getting Cardano genesis transactions')
       }
+      this.setBlockZeroForGenesisTransfers(transactions)
     }
 
     transactions = util.discardNotCompletedBlock(transactions)

--- a/blockchains/cardano/cardano_worker.js
+++ b/blockchains/cardano/cardano_worker.js
@@ -178,7 +178,6 @@ class CardanoWorker extends BaseWorker {
         throw new Error('Error getting Cardano genesis transactions')
       }
       this.setBlockZeroForGenesisTransfers(transactions)
-      this.lastExportedBlock = 0
     }
     else {
       const fromBlock = this.lastExportedBlock + 1
@@ -186,7 +185,6 @@ class CardanoWorker extends BaseWorker {
       if (transactions.length == 0) {
         return []
       }
-      this.lastExportedBlock = transactions[transactions.length - 1].block.number
     }
 
     transactions = util.discardNotCompletedBlock(transactions)
@@ -197,6 +195,7 @@ class CardanoWorker extends BaseWorker {
     }
 
     this.lastExportTime = Date.now()
+    this.lastExportedBlock = transactions[transactions.length - 1].block.number
     this.lastPrimaryKey += transactions.length
 
     return transactions

--- a/blockchains/cardano/cardano_worker.js
+++ b/blockchains/cardano/cardano_worker.js
@@ -113,7 +113,7 @@ class CardanoWorker extends BaseWorker {
       transactions(
         where: {
           block: { epoch: { number: { _is_null: false } } }
-          _and: { block: { number: { _gt: ${blockNumber} } } }
+          _and: { block: { number: { _gte: ${blockNumber} } } }
         }
         order_by: { includedAt: asc }
       ) {

--- a/blockchains/cardano/cardano_worker.js
+++ b/blockchains/cardano/cardano_worker.js
@@ -37,7 +37,7 @@ class CardanoWorker extends BaseWorker {
     return response.data.cardano.tip.number
   }
 
-  async getGenesisTransactionsPage(offset, limit) {
+  async getGenesisTransactionsPage(offset) {
     const response = await this.sendRequest(`
     {
       transactions(
@@ -45,7 +45,6 @@ class CardanoWorker extends BaseWorker {
             block: { hash: { _eq: "5f20df933584822601f9e3f8c024eb5eb252fe8cefb24d1317dc3d432e940ebb" } }
           }
           offset: ${offset}
-          limit: ${limit}
           order_by: { includedAt: asc }
         ) {
           includedAt
@@ -82,17 +81,16 @@ class CardanoWorker extends BaseWorker {
   }
 
   async getGenesisTransactions() {
-    const batch_size = 100
     let current_offset = 0
     const transactionsMerged = []
     let transactionsBatch = []
 
     do {
-      transactionsBatch = await this.getGenesisTransactionsPage(current_offset, batch_size)
+      transactionsBatch = await this.getGenesisTransactionsPage(current_offset)
       transactionsMerged.push(...transactionsBatch)
-      current_offset += batch_size
+      current_offset += transactionsBatch.length
     }
-    while (transactionsBatch.length == batch_size )
+    while (transactionsBatch.length == 0)
 
     return transactionsMerged
   }

--- a/blockchains/cardano/lib/util.js
+++ b/blockchains/cardano/lib/util.js
@@ -17,7 +17,7 @@ const { logger } = require('../../../lib/logger')
           Block number is ${lastBlockNumber} it has ${transactions[0].block.transactionsCount} but only
           ${transactions.length - 1} were extracted.`)
       }
-      logger.debug("Removing ", transactions.length - index, " transactions from partial block ", lastBlockNumber)
+      logger.debug(`Removing ${transactions.length - index} transactions from partial block ${lastBlockNumber}`)
       return transactions.slice(0, index + 1)
     }
 

--- a/blockchains/cardano/lib/util.js
+++ b/blockchains/cardano/lib/util.js
@@ -17,7 +17,7 @@ const { logger } = require('../../../lib/logger')
           Block number is ${lastBlockNumber} it has ${transactions[0].block.transactionsCount} but only
           ${transactions.length - 1} were extracted.`)
       }
-      logger.debug(`Removing ${transactions.length - index} transactions from partial block ${lastBlockNumber}`)
+      logger.debug(`Removing ${transactions.length - index - 1} transactions from partial block ${lastBlockNumber}`)
       return transactions.slice(0, index + 1)
     }
 

--- a/lib/worker_base.js
+++ b/lib/worker_base.js
@@ -5,8 +5,8 @@ class WorkerBase {
     // To prevent healthcheck failing during initialization and processing first
     // part of data, we set lastExportTime to current time.
     this.lastExportTime = Date.now()
-    this.lastConfirmedBlock = 0
-    this.lastExportedBlock = 0
+    this.lastConfirmedBlock = -1
+    this.lastExportedBlock = -1
     this.lastPrimaryKey = 0
     this.sleepTimeMsec = 0
   }

--- a/test/cardano/worker.spec.js
+++ b/test/cardano/worker.spec.js
@@ -190,6 +190,9 @@ describe('workLoopTest', function() {
     const expected = JSON.parse(JSON.stringify(genesisTransactions))
     expected[0].primaryKey = 1
     expected[1].primaryKey = 2
+    // Test also that we have overwritten the block numbers
+    expected[0].block.number = 0
+    expected[1].block.number = 0
 
     assert.deepStrictEqual(result, expected)
   })


### PR DESCRIPTION
Fixes on the Cardano exporter.

* Export the genesis transfers. The block which includes them do not have a number so our query missed them. We need to explicitly specify a block hash.
* Other fixes.