### PR TITLE
Use Erigon receipts call

### DIFF
--- a/blockchains/eth/eth_worker.js
+++ b/blockchains/eth/eth_worker.js
@@ -62,19 +62,17 @@ class ETHWorker extends BaseWorker {
     const responses = []
 
     for (const blockNumber of blockNumbers) {
-      const req = this.parityClient.request('parity_getBlockReceipts', [this.web3Wrapper.parseNumberToHex(blockNumber)], undefined, false)
+      const req = this.parityClient.request(constants.RECEIPTS_API_METHOD, [this.web3Wrapper.parseNumberToHex(blockNumber)], undefined, false)
       responses.push(this.parityClient.request([req]))
     }
 
     const finishedRequests = await Promise.all(responses)
     const result = {}
 
-
     finishedRequests.forEach((blockResponses) => {
       if (!blockResponses) return
 
       blockResponses.forEach((blockResponse) => {
-
         if (blockResponse.result) {
           blockResponse.result.forEach((receipt) => {
             result[receipt.transactionHash] = receipt

--- a/blockchains/eth/eth_worker.js
+++ b/blockchains/eth/eth_worker.js
@@ -69,14 +69,19 @@ class ETHWorker extends BaseWorker {
     const finishedRequests = await Promise.all(responses)
     const result = {}
 
+
     finishedRequests.forEach((blockResponses) => {
       if (!blockResponses) return
 
       blockResponses.forEach((blockResponse) => {
+
         if (blockResponse.result) {
           blockResponse.result.forEach((receipt) => {
             result[receipt.transactionHash] = receipt
           })
+        }
+        else {
+          throw new Error(JSON.stringify(blockResponse))
         }
       })
     })

--- a/blockchains/eth/lib/constants.js
+++ b/blockchains/eth/lib/constants.js
@@ -4,6 +4,10 @@ const PARITY_NODE = process.env.PARITY_URL || "http://localhost:8545/"
 const LOOP_INTERVAL_CURRENT_MODE_SEC = parseInt(process.env.LOOP_INTERVAL_CURRENT_MODE_SEC || "30")
 const BURN_ADDRESS = "burn"
 const LONDON_FORK_BLOCK = 12965000
+// This is the API method that Parity provides for fetching receipts across multiple blocks. Erigon instead provides
+// a method called 'eth_getBlockReceipts'. If we are deploying against Erigon, we need to overwrite this variable
+// through the deploy.
+const RECEIPTS_API_METHOD = process.env.RECEIPTS_API_METHOD || "parity_getBlockReceipts"
 
 module.exports = {
     BLOCK_INTERVAL,
@@ -11,5 +15,6 @@ module.exports = {
     PARITY_NODE,
     LOOP_INTERVAL_CURRENT_MODE_SEC,
     BURN_ADDRESS,
-    LONDON_FORK_BLOCK
+    LONDON_FORK_BLOCK,
+    RECEIPTS_API_METHOD
 }


### PR DESCRIPTION
Make the API call we use for fetching ETH receipts configurable. This allows us to run against different Full Nodes.