### PR TITLE
Increase Kafka init transaction timeout

### DIFF
--- a/lib/kafka_storage.js
+++ b/lib/kafka_storage.js
@@ -12,7 +12,7 @@ const BUFFERING_MAX_MESSAGES = parseInt(
 );
 const KAFKA_MESSAGE_MAX_BYTES = parseInt(process.env.KAFKA_MESSAGE_MAX_BYTES || "10485760")
 const FORMAT_HEADER = "format=json;";
-const TRANSACTIONS_TIMEOUT_MS = 2000;
+const TRANSACTIONS_TIMEOUT_MS = 10000;
 
 process.on("unhandledRejection", (reason, p) => {
   // Otherwise unhandled promises are not possible to trace with the information logged


### PR DESCRIPTION
When we run local tests like `./bin/run_matic.sh` using a HDD, it
takes more time to finish the `initTransaction` call than what was
allowed before (2 seconds). We increase the initTransaction timeout to
10 seconds in order to give sufficient time.