### PR TITLE
Enable running unit tests outside of docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,24 @@ If the health check does not pass you get response code 500 and a message descri
 
 ## Tests
 
-You can run the unit tests with:
+You can run the unit tests in one of the following ways:
 
+1) Without Docker
+You need to have `nodejs` installed locally.
+```bash
+$ npm install
+$ npm test
+```
+
+2) With Docker
 ```bash
 $ ./bin/test.sh
+```
 
 You can run the integration tests with:
+```bash
 $ ./e2e/test.sh
+```
 
 ## Writing exporters
 

--- a/blockchains/erc20/lib/constants.js
+++ b/blockchains/erc20/lib/constants.js
@@ -10,7 +10,13 @@ const PRIMARY_KEY_MULTIPLIER = 10000
 const CONTRACT_MODES_SUPPORTED = ["vanilla", "extract_exact_overwrite", "extract_all_append"]
 const CONTRACT_MODE = process.env.CONTRACT_MODE || "vanilla"
 const PARITY_NODE = process.env.PARITY_URL || "http://localhost:8545/"
-const CONTRACT_MAPPING_FILE_PATH = "./contract_mapping/contract_mapping.json"
+
+const CONTRACT_MAPPING_FILE_PATH = (
+    process.env.CONTRACT_MAPPING_FILE_PATH ?
+        "../../../"+process.env.CONTRACT_MAPPING_FILE_PATH :
+        "./contract_mapping/contract_mapping.json"
+)
+
 const LOOP_INTERVAL_CURRENT_MODE_SEC = parseInt(process.env.LOOP_INTERVAL_CURRENT_MODE_SEC || "30")
 const USE_TIMESTAMP_MANAGER = parseInt(process.env.USE_TIMESTAMP_MANAGER || "0")
 

--- a/docker/Dockerfile-test
+++ b/docker/Dockerfile-test
@@ -30,10 +30,8 @@ RUN apt-get update; \
 WORKDIR /opt/app
 
 ENV PATH /opt/node_modules/.bin:$PATH
-ENV CONTRACT_MODE "extract_exact_overwrite"
 
 COPY --from=builder /opt/node_modules /opt/node_modules
-COPY test/erc20/contract_mapping/ /opt/app/blockchains/erc20/lib/contract_mapping/
 
 COPY . /opt/app
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Exporter of all transfer events for a blockchain",
   "main": "index.js",
   "scripts": {
-    "test": "mocha --recursive --reporter spec",
+    "test": "CONTRACT_MAPPING_FILE_PATH=test/erc20/contract_mapping/contract_mapping.json CONTRACT_MODE=extract_exact_overwrite mocha --recursive --reporter spec",
     "lint": "eslint '**/*.js'",
     "start": "micro"
   },


### PR DESCRIPTION
There were two custom configurations done in Dockerfile-test:
1) copy of contract_mapping.json
2) set up of CONTRACT_MODE environment

Those customizations make it impossible to just run `npm test` outside
of docker.

We have made the following changes:

1) Added an environment variable which sets the path of the
contract_mapping.json file
2) Changed the `npm test` command to have the proper environment
variables set up
3) Removed the customizations from Dockerfile-test

As a result now it is possible to run `npm test` outside of Docker. On
my machine time of running unit tests went down as follows:

- run `./bin/test.sh` when no code changes were made - 4 seconds
- run `./bin/test.sh` when code changes were made - 7-8 seconds
- run `npm test` - 1.5 seconds