### PR TITLE
Refactor the common exporter code

### DIFF
--- a/lib/worker_base.js
+++ b/lib/worker_base.js
@@ -1,4 +1,5 @@
 "use strict";
+const { logger } = require('./logger')
 
 class WorkerBase {
   constructor() {
@@ -24,6 +25,51 @@ class WorkerBase {
   init() {
     throw new Error("'init' method need to be overriden")
   }
+
+  /**
+   * Should be overriden depending on blockchain implementation.
+   *
+   * @returns Number of new requests made towards the Node endpoint. Used for metrics purposes.
+   */
+  getNewRequestsCount() {
+    return 1
+  }
+
+  /**
+   *
+   * @param {Object} lastProcessedPosition Fill the object that is to be stored in Zookeeper. Additional fields
+   * may be stored at this point.
+   */
+  getLastProcessedPosition() {
+    return {
+      blockNumber: this.lastExportedBlock,
+      primaryKey: this.lastPrimaryKey
+    }
+  }
+
+  /**
+   * Initialize the position from which export should start based on latest stored position in Zookeeper.
+   * Would be invoked after init() above.
+   *
+   * Default implementation for exporters which progress per block number.
+   */
+  initPosition(lastProcessedPosition) {
+    if (lastProcessedPosition) {
+      logger.info(`Resuming export from position ${JSON.stringify(lastProcessedPosition)}`)
+    } else {
+      lastProcessedPosition = {
+        blockNumber: parseInt(process.env.START_BLOCK || "-1"),
+        primaryKey: parseInt(process.env.START_PRIMARY_KEY || "-1")
+      }
+      logger.info(`Initialized exporter with initial position ${JSON.stringify(lastProcessedPosition)}`)
+    }
+    this.lastExportedBlock = lastProcessedPosition.blockNumber
+    this.lastPrimaryKey = lastProcessedPosition.primaryKey
+
+    return lastProcessedPosition
+  }
+
+
   /**
    * A healthcheck metric for the blockchain. Can be a check on the Node and/or other.
    * Should return a Promise.


### PR DESCRIPTION
In this PR we refactor a part of the common exporter code. We move part of the logic from `index.js` to the base class we use for workers (`WorkerBase`). The code being there allows for specific worker implementations to overwrite it with specific logic. This refactor is intended to facilitate the introduction of BNB exporter. In this blockchain we fetch an API using time intervals instead of blocks, so part of the current presumptions were not valid anymore.

