### PR TITLE
Use generic Dockerfile in E2E test

### DIFF
--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -35,8 +35,7 @@ services:
   exporter:
     build:
       context: ../
-      # Reuse the Dockerfile used for the unit tests, however change the command.
-      dockerfile: docker/Dockerfile-test
+      dockerfile: docker/Dockerfile
       args:
         NODE_ENV: development
     depends_on:


### PR DESCRIPTION
In a previous [PR](https://github.com/santiment/san-chain-exporter/pull/78) I forgot to remove the mention of the Dockerfile-test form the End to End test.