### PR TITLE
BNB smarter fetch intervals

### DIFF
--- a/blockchains/bnb/lib/bnb_transactions_fetcher.js
+++ b/blockchains/bnb/lib/bnb_transactions_fetcher.js
@@ -9,14 +9,14 @@ const constants = require("./constants")
  * A class wrapping the tools for fetching transactions. It holds as state the position of the last fetch.
  */
 class BNBTransactionsFetcher {
-  constructor(lastIntervalFetchEnd) {
+  constructor(lastIntervalFetchEnd, msecInFetchRange) {
     // The timestamp of the last block produced. Will be reduced with real value.
     this.lastBlockTimestamp = 0
     /**
      * We start by fetching transactions for an hour. This will be dynamically reduced when the transactions
      * number increase.
      */
-    this.msecInFetchRange = constants.FETCH_INTERVAL_HISTORIC_MODE_MSEC
+    this.msecInFetchRange = msecInFetchRange
     this.intervalFetchStart = 0
     this.intervalFetchEnd = lastIntervalFetchEnd
     this.isUpToDateWithBlockchain = false
@@ -24,6 +24,10 @@ class BNBTransactionsFetcher {
 
   getIntervalFetchEnd() {
     return this.intervalFetchEnd
+  }
+
+  getMsecInFetchRange() {
+    return this.msecInFetchRange
   }
 
   // When the exporter catches up with the Node, we need to limit the range of blocks we query
@@ -65,11 +69,6 @@ class BNBTransactionsFetcher {
     this.isUpToDateWithBlockchain = ! nextRange.result
     if (!nextRange.result) {
       // Unable to move forward. Blockchain has not progressed.
-      //
-      // TODO: When the exporter has just started (or restart) it tries to work with a huge fetch interval.
-      // We do this for the 'historic' mode where there is less data in the blocks and we fetch a lot at once.
-      // However, this is not optimal for the 'current' mode. It waits for the blockchain to progress only to find out
-      // that the interval has too much data and to reduce it.
       logger.info(`Waiting for blockchain to reach timestamp ${nextRange.intervalFetchEnd} so we can fetch interval`)
       return []
     }

--- a/blockchains/bnb/lib/bnb_transactions_fetcher.js
+++ b/blockchains/bnb/lib/bnb_transactions_fetcher.js
@@ -38,7 +38,12 @@ class BNBTransactionsFetcher {
         result: true
       }
     }
-    return {result: false}
+    // Return the potential interval for logging purpose
+    return {
+      intervalFetchStart: potentialNewStart,
+      intervalFetchEnd: potentialNewEnd,
+      result: false
+    }
   }
 
   async tryGetNextIntervalWithNode(metrics) {
@@ -60,6 +65,12 @@ class BNBTransactionsFetcher {
     this.isUpToDateWithBlockchain = ! nextRange.result
     if (!nextRange.result) {
       // Unable to move forward. Blockchain has not progressed.
+      //
+      // TODO: When the exporter has just started (or restart) it tries to work with a huge fetch interval.
+      // We do this for the 'historic' mode where there is less data in the blocks and we fetch a lot at once.
+      // However, this is not optimal for the 'current' mode. It waits for the blockchain to progress only to find out
+      // that the interval has too much data and to reduce it.
+      logger.info(`Waiting for blockchain to reach timestamp ${nextRange.intervalFetchEnd} so we can fetch interval`)
       return []
     }
 

--- a/blockchains/bnb/lib/constants.js
+++ b/blockchains/bnb/lib/constants.js
@@ -6,6 +6,8 @@ const LOOP_INTERVAL_CURRENT_MODE_SEC = parseInt(process.env.LOOP_INTERVAL_CURREN
 const SAFETY_BLOCK_WAIT_MSEC = 100000
 // We start by fetching transactions for an hour. This will be dynamically reduced when the transactions number increase.
 const FETCH_INTERVAL_HISTORIC_MODE_MSEC =  parseInt(process.env.FETCH_INTERVAL_HISTORIC_MODE_MSEC || "3600000")
+// A smaller fetch interval to use in 'current' mode. By default 2 minutes. Would also be reduced if needed.
+const FETCH_INTERVAL_CURRENT_MODE_MSEC =  parseInt(process.env.FETCH_INTERVAL_HISTORIC_MODE_MSEC || "120000")
 // The biggest page we can ask the BNB API for. We should query a time interval small enough, so that it results fit in this number of pages.
 const BNB_API_MAX_PAGE = parseInt(process.env.BNB_API_MAX_PAGE || "100")
 // The maximum number of rows that can be requested according to the BNB API. The value is different depending on the request.
@@ -19,6 +21,7 @@ module.exports = {
     LOOP_INTERVAL_CURRENT_MODE_SEC,
     SAFETY_BLOCK_WAIT_MSEC,
     FETCH_INTERVAL_HISTORIC_MODE_MSEC,
+    FETCH_INTERVAL_CURRENT_MODE_MSEC,
     BNB_API_MAX_PAGE,
     MAX_NUM_ROWS_TIME_INTERVAL,
     SERVER_URL

--- a/test/bnb/bnb_transactions_fetcher.test.js
+++ b/test/bnb/bnb_transactions_fetcher.test.js
@@ -32,7 +32,8 @@ describe('intervalStartIsNotModified', function() {
   })
 
   it("Checking that the start interval for fetching transactions will not be modified.", async function() {
-    const bnbTransactionsFetcher = new bnb_transactions_fetcher.BNBTransactionsFetcher(START_TIMESTAMP)
+    const bnbTransactionsFetcher = new bnb_transactions_fetcher.BNBTransactionsFetcher(START_TIMESTAMP,
+      constants.FETCH_INTERVAL_CURRENT_MODE_MSEC)
 
     // The loop is only triggered here. The result would be saved in by the callback function.
     await bnbTransactionsFetcher.tryFetchTransactionsNextRange()
@@ -42,14 +43,15 @@ describe('intervalStartIsNotModified', function() {
 
   it("Checking that the end will be modified to stay into the present.", async function() {
     const bnbTransactionsFetcher = new bnb_transactions_fetcher.BNBTransactionsFetcher(
-      CURRENT_BLOCK_TIMESTAMP - constants.SAFETY_BLOCK_WAIT_MSEC
+      CURRENT_BLOCK_TIMESTAMP - constants.SAFETY_BLOCK_WAIT_MSEC,
+      constants.FETCH_INTERVAL_CURRENT_MODE_MSEC
     )
 
     await bnbTransactionsFetcher.tryFetchTransactionsNextRange()
 
     // Assert that the end interval is about to go into the future before corrections.
     assert(
-      bnbTransactionsFetcher.intervalFetchEnd + constants.FETCH_INTERVAL_HISTORIC_MODE_MSEC >
+      bnbTransactionsFetcher.intervalFetchEnd + bnbTransactionsFetcher.msecInFetchRange >
       bnb_transactions_fetcher.__get__("getLastBlockTimestamp")()
     )
 
@@ -68,7 +70,8 @@ describe('intervalStartIsNotModified', function() {
   async function() {
 
     const bnbTransactionsFetcher = new bnb_transactions_fetcher.BNBTransactionsFetcher(
-      CURRENT_BLOCK_TIMESTAMP - constants.SAFETY_BLOCK_WAIT_MSEC
+      CURRENT_BLOCK_TIMESTAMP - constants.SAFETY_BLOCK_WAIT_MSEC,
+      constants.FETCH_INTERVAL_CURRENT_MODE_MSEC
     )
 
     // Provide a start interval which matches the currently possible end interval. This can happen if the
@@ -91,7 +94,8 @@ describe('intervalStartIsNotModified', function() {
   async function() {
 
     const bnbTransactionsFetcher = new bnb_transactions_fetcher.BNBTransactionsFetcher(
-      CURRENT_BLOCK_TIMESTAMP - constants.SAFETY_BLOCK_WAIT_MSEC
+      CURRENT_BLOCK_TIMESTAMP - constants.SAFETY_BLOCK_WAIT_MSEC,
+      constants.FETCH_INTERVAL_CURRENT_MODE_MSEC
     )
 
     await bnbTransactionsFetcher.tryFetchTransactionsNextRange()
@@ -114,7 +118,8 @@ describe('intervalStartIsNotModified', function() {
   async function() {
     // Choose a start timestamp such, that only one interval is possible
     const bnbTransactionsFetcher = new bnb_transactions_fetcher.BNBTransactionsFetcher(
-      CURRENT_BLOCK_TIMESTAMP - constants.SAFETY_BLOCK_WAIT_MSEC - constants.FETCH_INTERVAL_HISTORIC_MODE_MSEC - 1
+      CURRENT_BLOCK_TIMESTAMP - constants.SAFETY_BLOCK_WAIT_MSEC - constants.FETCH_INTERVAL_CURRENT_MODE_MSEC - 1,
+      constants.FETCH_INTERVAL_CURRENT_MODE_MSEC
     )
     await bnbTransactionsFetcher.tryFetchTransactionsNextRange()
 
@@ -147,7 +152,8 @@ describe('intervalStartIsNotModified', function() {
       return false;
     })
 
-    const bnbTransactionsFetcher = new bnb_transactions_fetcher.BNBTransactionsFetcher(START_TIMESTAMP)
+    const bnbTransactionsFetcher = new bnb_transactions_fetcher.BNBTransactionsFetcher(START_TIMESTAMP,
+      constants.FETCH_INTERVAL_CURRENT_MODE_MSEC)
 
     // Assert that the next interval is possible
     const nextInterval = await bnbTransactionsFetcher.tryGetNextIntervalWithNode()


### PR DESCRIPTION
Implement more complex logic for setting correct BNB fetch interval.

* Store the value in Zookeeper along with the data for the last position
* Use the stored value when available unless it is very small, in which case increase to a 'current' value

This is a solution for the problem of how big a fetch interval to choose. When scrapping in 'historic' mode we want to use a big interval as there are few events on the blockchain and we have a huge time frame to cover. But in 'current' mode this interval should be small because we are hitting API limits.