### PR TITLE
Cardano close interval on right

### DIFF
--- a/blockchains/cardano/cardano_worker.js
+++ b/blockchains/cardano/cardano_worker.js
@@ -111,13 +111,14 @@ class CardanoWorker extends BaseWorker {
   }
 
   async getTransactions(blockNumber, lastConfirmedBlock) {
+    logger.info(`Getting transactions for interval ${blockNumber} - ${lastConfirmedBlock}`)
     const response = await this.sendRequest(`
     {
       transactions(
         where: {
           block: { epoch: { number: { _is_null: false } } }
           _and: [{ block: { number: { _gte: ${blockNumber} } } },
-                 { block: { number: { _lt: ${lastConfirmedBlock} } } }]
+                 { block: { number: { _lte: ${lastConfirmedBlock} } } }]
         }
         order_by: { includedAt: asc }
       ) {

--- a/blockchains/cardano/cardano_worker.js
+++ b/blockchains/cardano/cardano_worker.js
@@ -189,6 +189,7 @@ class CardanoWorker extends BaseWorker {
       const fromBlock = this.lastExportedBlock + 1
       transactions = await this.getTransactions(fromBlock, this.lastConfirmedBlock)
       if (transactions.length == 0) {
+        this.lastExportedBlock = this.lastConfirmedBlock
         return []
       }
     }

--- a/blockchains/cardano/lib/util.js
+++ b/blockchains/cardano/lib/util.js
@@ -4,49 +4,49 @@ const { logger } = require('../../../lib/logger')
    * It is expected that transactions for the last included in the batch block are not complete.
    * We discard the non completed block and would re-try it on next iteration.
    */
-   function discardNotCompletedBlock(transactions) {
-    const lastBlockNumber = transactions[transactions.length - 1].block.number
-    let index = transactions.length - 2
-    while (index >= 0 && transactions[index].block.number == lastBlockNumber) {
-      --index
-    }
+function discardNotCompletedBlock(transactions) {
+  const lastBlockNumber = transactions[transactions.length - 1].block.number
+  let index = transactions.length - 2
+  while (index >= 0 && transactions[index].block.number == lastBlockNumber) {
+    --index
+  }
 
-    if (transactions[index + 1].block.transactionsCount != transactions.length - index - 1) {
-      if (index < 0) {
-        throw new Error(`Single extracted block is partial. Exporter would not be able to progress.
+  if (transactions[index + 1].block.transactionsCount != transactions.length - index - 1) {
+    if (index < 0) {
+      throw new Error(`Single extracted block is partial. Exporter would not be able to progress.
           Block number is ${lastBlockNumber} it has ${transactions[0].block.transactionsCount} but only
           ${transactions.length - 1} were extracted.`)
-      }
-      logger.debug(`Removing ${transactions.length - index - 1} transactions from partial block ${lastBlockNumber}`)
-      return transactions.slice(0, index + 1)
     }
-
-    return transactions
+    logger.debug(`Removing ${transactions.length - index - 1} transactions from partial block ${lastBlockNumber}`)
+    return transactions.slice(0, index + 1)
   }
 
-  function verifyAllBlocksComplete(transactions) {
-    let lastBlockNumber = transactions[0].block.number
-    let transactionsInBlock = 1
+  return transactions
+}
 
-    for (let i = 1; i < transactions.length; i++) {
-      if (transactions[i].block.number != lastBlockNumber) {
-        // Check that all transactions are extracted
-        if (transactionsInBlock != transactions[i-1].block.transactionsCount) {
-           throw new Error(`The block ${lastBlockNumber} has ${transactions[i-1].block.transactionsCount}
+function verifyAllBlocksComplete(transactions) {
+  let lastBlockNumber = transactions[0].block.number
+  let transactionsInBlock = 1
+
+  for (let i = 1; i < transactions.length; i++) {
+    if (transactions[i].block.number != lastBlockNumber) {
+      // Check that all transactions are extracted
+      if (transactionsInBlock != transactions[i - 1].block.transactionsCount) {
+        throw new Error(`The block ${lastBlockNumber} has ${transactions[i - 1].block.transactionsCount}
             transactions but we extracted ${transactionsInBlock} transactions`)
-        }
-        transactionsInBlock = 0
-        lastBlockNumber = transactions[i].block.number
       }
-      ++transactionsInBlock
+      transactionsInBlock = 0
+      lastBlockNumber = transactions[i].block.number
     }
-
-    const expectedTrxInLastBlock = transactions[transactions.length - 1].block.transactionsCount
-    if (expectedTrxInLastBlock != transactionsInBlock) {
-         throw new Error(`The block ${lastBlockNumber} has ${expectedTrxInLastBlock}
-          transactions but we extracted ${transactionsInBlock} transactions`)
-      }
+    ++transactionsInBlock
   }
+
+  const expectedTrxInLastBlock = transactions[transactions.length - 1].block.transactionsCount
+  if (expectedTrxInLastBlock != transactionsInBlock) {
+    throw new Error(`The block ${lastBlockNumber} has ${expectedTrxInLastBlock}
+          transactions but we extracted ${transactionsInBlock} transactions`)
+  }
+}
 module.exports = {
   discardNotCompletedBlock, verifyAllBlocksComplete
 }

--- a/index.js
+++ b/index.js
@@ -54,13 +54,13 @@ class Main {
 
       const _this = this
       if (this.shouldWork) {
-        setTimeout(function() {_this.workLoop()}, _this.worker.sleepTimeMsec)
+        setTimeout(function () { _this.workLoop() }, _this.worker.sleepTimeMsec)
       }
       else {
         this.exporter.disconnect()
       }
     }
-    catch(ex) {
+    catch (ex) {
       console.error("Error in exporter work loop: ", ex)
       throw ex
     }
@@ -99,7 +99,7 @@ class Main {
     const isExportTimeoutExceeded = timeFromLastExport > constants.EXPORT_TIMEOUT_MLS
     if (isExportTimeoutExceeded) {
       const errorMessage = `Time from the last export ${timeFromLastExport}ms exceeded limit ` +
-        `${constants.EXPORT_TIMEOUT_MLS}ms.`
+        `${constants.EXPORT_TIMEOUT_MLS}ms. Node last block is ${this.worker.lastConfirmedBlock}.`
       return Promise.reject(errorMessage)
     } else {
       return Promise.resolve()
@@ -108,7 +108,7 @@ class Main {
 
   healthcheck() {
     return this.healthcheckKafka()
-    .then(() => this.healthcheckExportTimeout())
+      .then(() => this.healthcheckExportTimeout())
   }
 }
 
@@ -116,9 +116,9 @@ const main = new Main()
 main.init().then(() => {
   main.workLoop()
 })
-.catch((ex) => {
-  console.error("Error initializing exporter: ", ex)
-})
+  .catch((ex) => {
+    console.error("Error initializing exporter: ", ex)
+  })
 
 process.on('SIGINT', () => {
   main.stop()
@@ -131,11 +131,11 @@ module.exports = async (request, response) => {
   switch (req.pathname) {
     case '/healthcheck':
       return main.healthcheck()
-          .then(() => send(response, 200, "ok"))
-          .catch((err) => {
-            logger.error(`Healthcheck failed: ${err.toString()}`)
-            send(response, 500, err.toString())
-          })
+        .then(() => send(response, 200, "ok"))
+        .catch((err) => {
+          logger.error(`Healthcheck failed: ${err.toString()}`)
+          send(response, 500, err.toString())
+        })
     case '/metrics':
       response.setHeader('Content-Type', metrics.register.contentType);
       return send(response, 200, await metrics.register.metrics())


### PR DESCRIPTION
In this PR:
* Bugfix. When the Cardano exporter extracts interval without any transactions, it did not move the progress forward. Fixed now, test added.
* When extracting interval X to Y. Close the interval on the right, this simplifies the logic and the logs.
* Code style fixing.