### PR TITLE
Fix BSC transfers exp

### DIFF
--- a/blockchains/eth/lib/constants.js
+++ b/blockchains/eth/lib/constants.js
@@ -3,6 +3,7 @@ const CONFIRMATIONS = parseInt(process.env.CONFIRMATIONS || '3');
 const NODE_URL =  process.env.NODE_URL || process.env.PARITY_URL || 'http://localhost:8545/';
 const LOOP_INTERVAL_CURRENT_MODE_SEC = parseInt(process.env.LOOP_INTERVAL_CURRENT_MODE_SEC || '30');
 const BURN_ADDRESS = 'burn';
+const IS_ETH = parseInt(process.env.IS_ETH || '1');
 const LONDON_FORK_BLOCK = 12965000;
 // This is the API method that Parity provides for fetching receipts across multiple blocks. Erigon instead provides
 // a method called 'eth_getBlockReceipts'. If we are deploying against Erigon, we need to overwrite this variable
@@ -15,6 +16,7 @@ module.exports = {
     NODE_URL,
     LOOP_INTERVAL_CURRENT_MODE_SEC,
     BURN_ADDRESS,
+    IS_ETH,
     LONDON_FORK_BLOCK,
     RECEIPTS_API_METHOD
 };

--- a/blockchains/eth/lib/fees_decoder.js
+++ b/blockchains/eth/lib/fees_decoder.js
@@ -73,7 +73,7 @@ class FeesDecoder {
     block.transactions.forEach((transaction) => {
       const blockNumber = this.web3Wrapper.parseHexToNumber(block.number);
       const feeTransfers =
-        blockNumber >= constants.LONDON_FORK_BLOCK ?
+        constants.IS_ETH && blockNumber >= constants.LONDON_FORK_BLOCK ?
         this.getPostLondonForkFees(transaction, block, receipts) :
         this.getPreLondonForkFees(transaction, block, receipts);
 


### PR DESCRIPTION
## Problem

BSC Transfers Exporter failed on staging, block's data was missing the 'baseFeePerGas' key, turned out that the London fork block got reached

## Solution
Since the BSC Transfers Exporter uses the functionality of the ETH one, and doesn't have a London fork, I've added a small bit of code, so that I could tweak the London fork variables in BSC's favour.