### PR TITLE
Copy filter_errors.js file from blockchain-utils repo

### DIFF
--- a/blockchains/eth/eth_worker.js
+++ b/blockchains/eth/eth_worker.js
@@ -1,6 +1,6 @@
 const Web3 = require('web3');
 const jayson = require('jayson/promise');
-const { filterErrors } = require('blockchain-utils/eth');
+const { filterErrors } = require('./lib/filter_errors');
 const constants = require('./lib/constants');
 const { logger } = require('../../lib/logger');
 const { injectDAOHackTransfers, DAO_HACK_FORK_BLOCK } = require('./lib/dao_hack');
@@ -105,7 +105,7 @@ class ETHWorker extends BaseWorker {
     let events = [];
     if (fromBlock === 0) {
       logger.info('Adding the GENESIS transfers');
-      events.push(... getGenesisTransfers(this.web3));
+      events.push(...getGenesisTransfers(this.web3));
     }
 
     events.push(... await this.getPastTransferEvents(traces, blocks));

--- a/blockchains/eth/lib/filter_errors.js
+++ b/blockchains/eth/lib/filter_errors.js
@@ -1,7 +1,28 @@
 const trie = require('trie-prefix-tree')
 const { groupBy } = require('lodash')
 
+/**
+ * A function to mark children traces as erroneous if their parent is an error.
+ *
+ * To achieve this we depend on the `traceAddress` field. The `traceAddress` field of all returned traces,
+ * gives the exact location in the call trace [index in root, index in first CALL, index in second CALL, …].
+ * i.e. trace with traceAddress for this call on the right
+ *
+ *
+ * A                  []
+ *   CALLs B          [0]
+ *     CALLs G        [0, 0]
+ *   CALLs C          [1]
+ *     CALLs G        [1, 0]
+ *
+ * When a call with trace [X, Y] is an error, this has the implication that all calls with traces looking like:
+ * [X, Y, ...] should also be marked as error. To implement this we use a Trie data structure.
+ *
+ * @param {A} traces
+ * @returns
+ */
 function setErrors(traces) {
+  // The whole computation is done per transaction
   let txs = groupBy(traces, tx => tx.transactionHash)
   const hashes = Object.keys(txs)
 
@@ -30,7 +51,20 @@ function setErrors(traces) {
 
 }
 
+/** Remove traces which contain no useful data. For example:
+ {
+     "error": {
+         "code": -32000,
+         "message": "first run for txIndex 323 error: insufficient funds for gas * price + value: address 0xb64a30399f7F6b0C154c2E7Af0a3ec7B0A5b131a have 79011297267895730 want 79314366712002216"
+     }
+ }
+*/
+function filterNonActions(traces) {
+  return traces.filter(trace => typeof trace.action != 'undefined')
+}
+
 function filterErrors(traces) {
+  traces = filterNonActions(traces)
   traces = setErrors(traces)
   traces = traces.filter(trace => typeof trace.error === 'undefined')
   return traces

--- a/blockchains/eth/lib/filter_errors.js
+++ b/blockchains/eth/lib/filter_errors.js
@@ -1,0 +1,41 @@
+const trie = require('trie-prefix-tree')
+const { groupBy } = require('lodash')
+
+function setErrors(traces) {
+  let txs = groupBy(traces, tx => tx.transactionHash)
+  const hashes = Object.keys(txs)
+
+  hashes.forEach(hash => {
+    const txTraces = txs[hash]
+
+    const errorTraces = txTraces.filter(trace => typeof trace.error !== 'undefined')
+    if (errorTraces.length === 0) return
+
+    const traceAddresses = txTraces.map(trace => (trace.traceAddress.length > 0) ? '-1 ' + trace.traceAddress.join(' ') : '-1 ')
+    const txTrie = trie(traceAddresses)
+
+    let errAddresses = errorTraces.map(trace => {
+      const errPrefix = '-1 ' + trace.traceAddress.join(' ')
+      const children = txTrie.getPrefix(errPrefix)
+      return children
+    })
+    errAddresses = [].concat(...errAddresses)
+    txs[hash].forEach(trace => {
+      if (errAddresses.indexOf('-1 ' + trace.traceAddress.join(' ')) !== -1) {
+        trace['error'] = 'parent_error'
+      }
+    })
+  })
+  return [].concat(...Object.values(txs))
+
+}
+
+function filterErrors(traces) {
+  traces = setErrors(traces)
+  traces = traces.filter(trace => typeof trace.error === 'undefined')
+  return traces
+}
+
+module.exports = {
+  filterErrors
+}

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
   "homepage": "https://github.com/santiment/erc20_transfers_exporter#readme",
   "dependencies": {
     "bignumber.js": "^9.0.0",
-    "blockchain-utils": "git+https://github.com/santiment/blockchain-utils.git#9761ff7b11c889aad2942b1ba47294bc4d705558",
     "got": "^11.8.2",
     "jayson": "^3.5.2",
     "micro": "^9.3.4",
@@ -30,7 +29,9 @@
     "p-queue": "^7.2.0",
     "prom-client": "^13.1.0",
     "segfault-handler": "^1.3.0",
-    "web3": "^1.2.11"
+    "web3": "^1.2.11",
+    "lodash": "^4.17.21",
+    "trie-prefix-tree": "^1.5.1"
   },
   "devDependencies": {
     "eslint": "^7.8.1",


### PR DESCRIPTION
This PR copies the only file in the [repo](https://github.com/santiment/blockchain-utils). I think having a repo with a single utility file doesn't make sense. Moreover I have identified that this filter function works **_very_** slow for some blocks, starving the Node thread for 20-30 seconds. I would fix this in another PR.

As next step we can deprecate the `blockchain-utils` repo.