### PR TITLE
XRP tests added. Minor Fixes.

### DIFF
--- a/blockchains/xrp/lib/constants.js
+++ b/blockchains/xrp/lib/constants.js
@@ -8,7 +8,7 @@ const CONNECTIONS_COUNT = parseInt(process.env.CONNECTIONS_COUNT || '1');
 const MAX_CONNECTION_CONCURRENCY = parseInt(process.env.MAX_CONNECTION_CONCURRENCY || '10');
 const XRP_NODE_URLS = process.env.XRP_NODE_URLS || 'wss://s2.ripple.com';
 const EXPORT_TIMEOUT_MLS = parseInt(process.env.EXPORT_TIMEOUT_MLS || 1000 * 60 * 5);
-const LOOP_INTERVAL_CURRENT_MODE_SEC = 1000;
+const LOOP_INTERVAL_CURRENT_MODE_SEC = parseInt(process.env.LOOP_INTERVAL_CURRENT_MODE_SEC || '30');
 
 module.exports = {
   SEND_BATCH_SIZE,

--- a/blockchains/xrp/xrp_worker.js
+++ b/blockchains/xrp/xrp_worker.js
@@ -84,7 +84,8 @@ class XRPWorker extends BaseWorker {
 
       transactions = await Promise.all(transactions);
 
-      transactions = transactions.filter(t => t);
+      // When transactions are fetched one by one, we need to take the 'result' field
+      transactions = transactions.map(t => t.result);
 
       return { ledger: ledger, transactions };
     }

--- a/blockchains/xrp/xrp_worker.js
+++ b/blockchains/xrp/xrp_worker.js
@@ -13,7 +13,7 @@ class XRPWorker extends BaseWorker {
   }
 
   async createNewSetConnections() {
-    PQueue = (await import('p-queue')).default;
+    const PQueue = (await import('p-queue')).default;
     if (this.nodeURLs.length === 0) {
       throw 'Error: All API URLs returned error.';
     }

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,12 +5,12 @@ ENV NODE_ENV=${NODE_ENV}
 
 RUN apt-get update; \
     apt-get install -y bash \
-      g++ \
-      ca-certificates \
-      musl-dev \
-      make \
-      git \
-      python3
+    g++ \
+    ca-certificates \
+    musl-dev \
+    make \
+    git \
+    python3
 
 WORKDIR /opt
 
@@ -30,7 +30,13 @@ ENV PATH /opt/node_modules/.bin:$PATH
 
 COPY --from=builder /opt/node_modules /opt/node_modules
 
-COPY . /opt/app
+#
+# Reason for multipe COPY commands is Docker CP limitation, it copies <src> contents only not preserving the directory
+#
+COPY package.json AUTHORS LICENSE index.js /opt/app/
+COPY blockchains /opt/app/blockchains
+COPY lib/ /opt/app/lib
+COPY test /opt/app/test
 
 EXPOSE 3000
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -37,6 +37,7 @@ COPY package.json AUTHORS LICENSE index.js /opt/app/
 COPY blockchains /opt/app/blockchains
 COPY lib/ /opt/app/lib
 COPY test /opt/app/test
+COPY docker/wait_for_services.sh /opt/app/docker
 
 EXPOSE 3000
 

--- a/index.js
+++ b/index.js
@@ -83,6 +83,7 @@ class Main {
   }
 
   stop() {
+    logger.info('Triggering exporter stop');
     this.shouldWork = false;
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "san-chain-exporter",
       "version": "0.1.3",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -10,14 +10,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/santiment/erc20_transfers_exporter.git"
+    "url": "git+https://github.com/santiment/san-chain-exporter.git"
   },
   "author": "Santiment",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/santiment/erc20_transfers_exporter/issues"
+    "url": "https://github.com/santiment/san-chain-exporter/issues"
   },
-  "homepage": "https://github.com/santiment/erc20_transfers_exporter#readme",
+  "homepage": "https://github.com/santiment/san-chain-exporter#readme",
   "dependencies": {
     "bignumber.js": "^9.0.0",
     "got": "^11.8.2",

--- a/test/xrp/worker.test.js
+++ b/test/xrp/worker.test.js
@@ -1,0 +1,82 @@
+/*jshint esversion: 6 */
+const assert = require('assert');
+
+const xrp_worker = require('../../blockchains/xrp/xrp_worker');
+
+/** A stripped down XRP block */
+const xrpBlock = {
+  'ledger': {
+    'accepted': true,
+    'hash': '01AFAE9D64B549B014EC1FCCEB7A0EBFA34A0BE3D84B4909B3C9D7B7B0DE076A',
+    'ledger_hash': '01AFAE9D64B549B014EC1FCCEB7A0EBFA34A0BE3D84B4909B3C9D7B7B0DE076A',
+    'ledger_index': '3232710',
+    'transaction_hash': '0993BFF01B90E030E065ECA2752EB563466FCA31356CBA2C495B5E5407117FC5',
+    'transactions': [
+      'D52DC46F5E7EB1068256AF2C42331CC23AC9F0C83824A1909F2141FEC001DBCF'
+    ]
+  },
+  'transactions': [
+    {
+      'Account': 'rUqNn26jQG8zfNDy21NTCwgFXrFgLyRf3U',
+      'Fee': '10',
+      'Flags': 0,
+      'Sequence': 101317,
+      'SigningPubKey': '02B1A8D1DF2C281BA7A872B59E765A0CE7B7A31D8A7ACD7030DA2E45C4D33CF2C4',
+      'metaData': {
+        'AffectedNodes': []
+      }
+    }
+  ]
+};
+
+
+
+const mockFetchLedgerTransactions = (connection, ledger_index) => {
+  const localBlock = structuredClone(xrpBlock);
+  localBlock.ledger.ledger_index = ledger_index;
+  return localBlock;
+};
+
+describe('workLoopSimpleTest', function () {
+  it('Checking that position is being updated', async function () {
+    const worker = new xrp_worker.worker();
+    worker.fetchLedgerTransactions = mockFetchLedgerTransactions;
+
+    // Set a huge last confirmed Node block, so that we do not ask the node and mock more easily.
+    worker.lastExportedBlock = 10;
+    worker.lastConfirmedBlock = 20;
+    await worker.work();
+
+    const lastProcessedPosition = worker.getLastProcessedPosition();
+
+    // The above loop should have progressed the lastProcessedPosition to the last known Node block
+    assert.deepStrictEqual(
+      lastProcessedPosition,
+      {
+        blockNumber: 20,
+        primaryKey: 20
+      }
+    );
+  });
+
+  it('Checking that expected result is returned', async function () {
+    const worker = new xrp_worker.worker();
+    worker.fetchLedgerTransactions = mockFetchLedgerTransactions;
+
+    // Set a huge last confirmed Node block, so that we do not ask the node and mock more easily.
+    worker.lastExportedBlock = 10;
+    worker.lastConfirmedBlock = 20;
+    const result = await worker.work();
+
+    const expectedResult = [];
+
+    for (let ledger_index = 11; ledger_index <= 20; ++ledger_index) {
+      const localBlock = structuredClone(xrpBlock);
+      localBlock.ledger.ledger_index = ledger_index;
+      localBlock.primaryKey = ledger_index;
+      expectedResult.push(localBlock);
+    }
+    assert.deepStrictEqual(result, expectedResult);
+  });
+
+});


### PR DESCRIPTION
In this PR:
* When fetching per-transaction the new API would return the result into a field named `result`, that is what we need to process.
* Some XRP tests added
* Configurable LOOP_INTERVAL_CURRENT_MODE_SEC
* Return primary key so that it is logged as part of progress
* Do not copy whole directory inside running image but pick specific files. In this way local `node_modules` is not copied, we want to take it from the Builder image
* Postpone loading of PQueue as it was causing Segfault error on testing