### PR TITLE
Use zookeeper-client instead of abandoned zookeeper-client-async

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -37,7 +37,7 @@ COPY package.json AUTHORS LICENSE index.js /opt/app/
 COPY blockchains /opt/app/blockchains
 COPY lib/ /opt/app/lib
 COPY test /opt/app/test
-COPY docker/wait_for_services.sh /opt/app/docker
+COPY docker/wait_for_services.sh /opt/app/docker/wait_for_services.sh
 
 EXPOSE 3000
 

--- a/lib/kafka_storage.js
+++ b/lib/kafka_storage.js
@@ -1,5 +1,5 @@
 const Kafka = require('node-rdkafka');
-const zk = require('node-zookeeper-client-async');
+const ZookeeperClientAsync = require('./zookeeper_client_async');
 const { logger, SYSLOG_LOG_LEVEL, log_according_to_syslog_level } = require('./logger');
 
 const ZOOKEEPER_URL = process.env.ZOOKEEPER_URL || 'localhost:2181';
@@ -10,7 +10,7 @@ const ZOOKEEPER_RETRIES = parseInt(process.env.ZOOKEEPER_RETRIES || '0');
 const KAFKA_COMPRESSION_CODEC = process.env.KAFKA_COMPRESSION_CODEC || 'lz4';
 const KAFKA_URL = process.env.KAFKA_URL || 'localhost:9092';
 const KAFKA_FLUSH_TIMEOUT = parseInt(process.env.KAFKA_FLUSH_TIMEOUT || '5000');
-const RDKAFKA_DEBUG=process.env.RDKAFKA_DEBUG || null;
+const RDKAFKA_DEBUG = process.env.RDKAFKA_DEBUG || null;
 const BUFFERING_MAX_MESSAGES = parseInt(
   process.env.BUFFERING_MAX_MESSAGES || '150000'
 );
@@ -32,7 +32,7 @@ process.on('unhandledRejection', (reason, p) => {
 });
 
 exports.Exporter = class {
-  constructor(exporter_name, transactional=false) {
+  constructor(exporter_name, transactional = false) {
     this.exporter_name = exporter_name;
     var producer_settings = {
       'metadata.broker.list': KAFKA_URL,
@@ -49,21 +49,21 @@ exports.Exporter = class {
     }
 
     if (transactional) {
-        producer_settings['transactional.id'] = this.topicName;
-        producer_settings['enable.idempotence'] = true;
+      producer_settings['transactional.id'] = this.topicName;
+      producer_settings['enable.idempotence'] = true;
     }
 
     this.producer = new Kafka.Producer(producer_settings);
 
-    this.producer.on('event.log', function(log) {
-        log_according_to_syslog_level(log.severity, log.fac, log.message);
+    this.producer.on('event.log', function (log) {
+      log_according_to_syslog_level(log.severity, log.fac, log.message);
     });
 
-    this.zookeeperClient = zk.createAsyncClient(ZOOKEEPER_URL,
+    this.zookeeperClient = new ZookeeperClientAsync(ZOOKEEPER_URL,
       {
-          sessionTimeout: ZOOKEEPER_SESSION_TIMEOUT,
-          spinDelay : ZOOKEEPER_SPIN_DELAY,
-          retries : ZOOKEEPER_RETRIES
+        sessionTimeout: ZOOKEEPER_SESSION_TIMEOUT,
+        spinDelay: ZOOKEEPER_SPIN_DELAY,
+        retries: ZOOKEEPER_RETRIES
       }
     );
   }
@@ -93,7 +93,7 @@ exports.Exporter = class {
     try {
       await this.zookeeperClient.connectAsync();
     }
-    catch(ex) {
+    catch (ex) {
       console.error('Error connecting to Zookeeper: ', ex);
       throw ex;
     }
@@ -104,8 +104,8 @@ exports.Exporter = class {
       this.producer.on('event.error', reject);
       // The user can provide a callback for delivery reports with the
       // dedicated method 'subscribeDeliveryReports'.
-      this.producer.on('delivery-report', function(err) {
-        if(err) {
+      this.producer.on('delivery-report', function (err) {
+        if (err) {
           throw err;
         }
       });
@@ -120,7 +120,7 @@ exports.Exporter = class {
    */
   disconnect(callback) {
     logger.info(`Disconnecting from zookeeper host ${ZOOKEEPER_URL}`);
-    this.zookeeperClient.closeAsync().then( () => {
+    this.zookeeperClient.closeAsync().then(() => {
       if (this.producer.isConnected()) {
         logger.info(`Disconnecting from kafka host ${KAFKA_URL}`);
         this.producer.disconnect(callback);
@@ -264,15 +264,15 @@ exports.Exporter = class {
    * @param {Function} Callback to be invoked on message delivery.
    */
   async subscribeDeliveryReports(callback) {
-     this.producer.on('delivery-report', callback);
+    this.producer.on('delivery-report', callback);
   }
 
   /**
    * Unsubscribe from delivery reports, restoring the default error checking.
    */
   async unSubscribeDeliveryReports() {
-    this.producer.on('delivery-report', function(err) {
-      if(err) {
+    this.producer.on('delivery-report', function (err) {
+      if (err) {
         throw err;
       }
     });
@@ -282,7 +282,7 @@ exports.Exporter = class {
     const promise = new Promise((resolve, reject) => {
       this.producer.initTransactions(TRANSACTIONS_TIMEOUT_MS, (err) => {
         if (err) {
-            return reject(err);
+          return reject(err);
         }
 
         resolve();
@@ -310,7 +310,7 @@ exports.Exporter = class {
     const promise = new Promise((resolve, reject) => {
       this.producer.commitTransaction(TRANSACTIONS_TIMEOUT_MS, (err) => {
         if (err) {
-            return reject(err);
+          return reject(err);
         }
 
         resolve();
@@ -324,7 +324,7 @@ exports.Exporter = class {
     const promise = new Promise((resolve, reject) => {
       this.producer.abortTransactions(TRANSACTIONS_TIMEOUT_MS, (err) => {
         if (err) {
-            return reject(err);
+          return reject(err);
         }
 
         resolve();

--- a/lib/zookeeper_client_async.js
+++ b/lib/zookeeper_client_async.js
@@ -1,0 +1,127 @@
+const zk = require('node-zookeeper-client');
+
+class ZookeeperClientAsync {
+  constructor(zookeeperUrl, options) {
+    this._client = zk.createClient(zookeeperUrl, options)
+  }
+
+  /**
+   * Initiate the connection to the provided server list (ensemble). The client will
+   * pick an arbitrary server from the list and attempt to connect to it. If the
+   * establishment of the connection fails, another server will be tried (picked
+   * randomly) until a connection is established or close method is invoked.
+   * @returns {Promise} resolves on connect. Rejects with message on failure.
+   */
+  connectAsync() {
+    return new Promise((resolve, reject) => {
+      this._client.once('connected', () => resolve());
+      this._client.once('connectedReadOnly', () => resolve());
+      this._client.once('authenticationFailed', () => reject('Authentication failed.'));
+      this._client.once('disconnected', () => reject('Client disconnected before it could open a successful connection.'));
+      this._client.connect();
+    });
+  }
+
+  /**
+   * Close this client. Once the client is closed, its session becomes invalid. All the
+   * ephemeral nodes in the ZooKeeper server associated with the session will be
+   * removed. The watchers left on those nodes (and on their parents) will be triggered.
+   * Resolves true when the client disconnects, resolves false if the client is already
+   * disconnected.
+   * @returns {Promise} resolves when disconnected. Does not reject.
+   */
+  closeAsync() {
+    return new Promise((resolve, reject) => {
+      if (this._client.getState() === zk.State.DISCONNECTED) {
+        resolve(false);
+      } else {
+        this._client.once('disconnected', () => resolve(true));
+        this._client.close();
+      }
+    });
+  }
+
+  /**
+   * For the given node path, retrieve the children list and the stat. The children will
+   * be an unordered list of strings. Resolves the stat object if the node exists,
+   * resolves null if it does not exist, rejects if anything goes wrong.
+   * @param {string} path the Path of the node.
+   * @returns {Promise}
+   */
+  existsAsync(path) {
+    return new Promise((resolve, reject) => {
+      this._client.exists(path, null, (e, stat) => {
+        if (e) {
+          reject(e);
+        } else {
+          resolve(stat);
+        }
+      });
+    });
+  }
+
+  /**
+   * Retrieve the data and the stat of the node of the given path. Resolves an object
+   * containing data as a Buffer object and stat as the stat object. Resolves null
+   * if the node does not exist. Rejects if anything goes wrong.
+   * @param {string} path the Path of the node.
+   * @returns {Promise}
+   */
+  getDataAsync(path) {
+    return new Promise((resolve, reject) => {
+      this._client.getData(path, null, (e, data, stat) => {
+        if (e) {
+          if (e.code === zk.Exception.NO_NODE) resolve(null);
+          else reject(e);
+        } else {
+          resolve({ data, stat });
+        }
+      });
+    });
+  }
+
+  /**
+   * Set the data for the node of the given path if such a node exists and the optional
+   * given version matches the version of the node (if the given version is -1, it
+   * matches any node's versions). Will resolve the stat of the node if successful. Will
+   * reject if unsuccessful or if the node does not exist.
+   * @param {string} path the Path of the node.
+   * @param {Buffer} data the data to set on the node.
+   * @param {Number} version the version to set. -1 (default) to match any version.
+   * @returns {Promise}
+   */
+  setDataAsync(path, data, version = -1) {
+    return new Promise((resolve, reject) => {
+      this._client.setData(path, data, version, (e, stat) => {
+        if (e) {
+          reject(e);
+        } else {
+          resolve(stat);
+        }
+      });
+    });
+  }
+
+  /**
+   * Create given path in a way similar to mkdir -p. Will resolve the path if the node
+   * is created and will reject if anything goes wrong.
+   * @param {string} path the Path of the node.
+   * @param {Buffer} data The data buffer, optional, defaults to null.
+   * @param {ACL[]} acls  array of ACL objects, optional, defaults to ACL.OPEN_ACL_UNSAFE
+   * @param {CreateMode} mode The creation mode, optional, defaults to CreateMode.PERSISTENT
+   * @return {Promise}
+   */
+  mkdirpAsync(path, data = null, acls = null, mode = null) {
+    return new Promise((resolve, reject) => {
+      this._client.mkdirp(path, data, acls, mode, (e, path) => {
+        if (e) {
+          reject(e);
+        } else {
+          resolve(path);
+        }
+      });
+    });
+  }
+}
+
+module.exports = ZookeeperClientAsync;

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "micro": "^9.3.4",
         "node-json-logger": "^0.0.17",
         "node-rdkafka": "2.12.0",
-        "node-zookeeper-client-async": "^1.0.0",
+        "node-zookeeper-client": "^1.1.3",
         "p-queue": "^7.2.0",
         "prom-client": "^13.1.0",
         "segfault-handler": "^1.3.0",
@@ -131,18 +131,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/@babel/parser": {
-      "version": "7.13.16",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.16.tgz",
-      "integrity": "sha512-6bAg36mCwuqLO0hbR+z7PHuqWiCeP7Dzg73OpQwsAB1Eb8HnGEz5xYBzCfbu+YjoaJsJs+qheDxVAuqbt3ILEw==",
-      "optional": true,
-      "bin": {
-        "parser": "bin/babel-parser.js"
-      },
-      "engines": {
-        "node": ">=6.0.0"
       }
     },
     "node_modules/@eslint/eslintrc": {
@@ -852,7 +840,7 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "sprintf-js": "~1.0.2"
       }
@@ -915,9 +903,9 @@
       }
     },
     "node_modules/async": {
-      "version": "0.2.10",
-      "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-      "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E="
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
+      "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ=="
     },
     "node_modules/async-limiter": {
       "version": "1.0.1",
@@ -1427,18 +1415,6 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
-    },
-    "node_modules/catharsis": {
-      "version": "0.8.11",
-      "resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.8.11.tgz",
-      "integrity": "sha512-a+xUyMV7hD1BrDQA/3iPV7oc+6W26BgVJO05PGEoatMyIuPScQKsde6i3YorWX1qs+AZjnJ18NqdKoCtKiNh1g==",
-      "optional": true,
-      "dependencies": {
-        "lodash": "^4.17.14"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
     },
     "node_modules/chalk": {
       "version": "4.1.1",
@@ -1965,12 +1941,6 @@
       "engines": {
         "node": ">=8.6"
       }
-    },
-    "node_modules/entities": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.3.tgz",
-      "integrity": "sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ==",
-      "optional": true
     },
     "node_modules/es-abstract": {
       "version": "1.18.0",
@@ -3575,56 +3545,10 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
     },
-    "node_modules/js2xmlparser": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/js2xmlparser/-/js2xmlparser-4.0.1.tgz",
-      "integrity": "sha512-KrPTolcw6RocpYjdC7pL7v62e55q7qOMHvLX1UCLc5AAS8qeJ6nukarEJAF2KL2PZxlbGueEbINqZR2bDe/gUw==",
-      "optional": true,
-      "dependencies": {
-        "xmlcreate": "^2.0.3"
-      }
-    },
     "node_modules/jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
-    },
-    "node_modules/jsdoc": {
-      "version": "3.6.6",
-      "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.6.6.tgz",
-      "integrity": "sha512-znR99e1BHeyEkSvgDDpX0sTiTu+8aQyDl9DawrkOGZTTW8hv0deIFXx87114zJ7gRaDZKVQD/4tr1ifmJp9xhQ==",
-      "optional": true,
-      "dependencies": {
-        "@babel/parser": "^7.9.4",
-        "bluebird": "^3.7.2",
-        "catharsis": "^0.8.11",
-        "escape-string-regexp": "^2.0.0",
-        "js2xmlparser": "^4.0.1",
-        "klaw": "^3.0.0",
-        "markdown-it": "^10.0.0",
-        "markdown-it-anchor": "^5.2.7",
-        "marked": "^0.8.2",
-        "mkdirp": "^1.0.4",
-        "requizzle": "^0.2.3",
-        "strip-json-comments": "^3.1.0",
-        "taffydb": "2.6.2",
-        "underscore": "~1.10.2"
-      },
-      "bin": {
-        "jsdoc": "jsdoc.js"
-      },
-      "engines": {
-        "node": ">=8.15.0"
-      }
-    },
-    "node_modules/jsdoc/node_modules/escape-string-regexp": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
-      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
-      "optional": true,
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/json-buffer": {
       "version": "3.0.1",
@@ -3718,15 +3642,6 @@
         "json-buffer": "3.0.1"
       }
     },
-    "node_modules/klaw": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/klaw/-/klaw-3.0.0.tgz",
-      "integrity": "sha512-0Fo5oir+O9jnXu5EefYbVK+mHMBeEVEy2cmctR1O1NECcCkPRreJKrS6Qt/j3KC2C148Dfo9i3pCmCMsdqGr0g==",
-      "optional": true,
-      "dependencies": {
-        "graceful-fs": "^4.1.9"
-      }
-    },
     "node_modules/levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -3738,15 +3653,6 @@
       },
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/linkify-it": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.2.0.tgz",
-      "integrity": "sha512-GnAl/knGn+i1U/wjBz3akz2stz+HrHLsxMwHQGofCDfPvlf+gDKN58UtfmUquTY4/MXeE2x7k19KQmeoZi94Iw==",
-      "optional": true,
-      "dependencies": {
-        "uc.micro": "^1.0.1"
       }
     },
     "node_modules/locate-path": {
@@ -3817,43 +3723,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/markdown-it": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-10.0.0.tgz",
-      "integrity": "sha512-YWOP1j7UbDNz+TumYP1kpwnP0aEa711cJjrAQrzd0UXlbJfc5aAq0F/PZHjiioqDC1NKgvIMX+o+9Bk7yuM2dg==",
-      "optional": true,
-      "dependencies": {
-        "argparse": "^1.0.7",
-        "entities": "~2.0.0",
-        "linkify-it": "^2.0.0",
-        "mdurl": "^1.0.1",
-        "uc.micro": "^1.0.5"
-      },
-      "bin": {
-        "markdown-it": "bin/markdown-it.js"
-      }
-    },
-    "node_modules/markdown-it-anchor": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-5.3.0.tgz",
-      "integrity": "sha512-/V1MnLL/rgJ3jkMWo84UR+K+jF1cxNG1a+KwqeXqTIJ+jtA8aWSHuigx8lTzauiIjBDbwF3NcWQMotd0Dm39jA==",
-      "optional": true,
-      "peerDependencies": {
-        "markdown-it": "*"
-      }
-    },
-    "node_modules/marked": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.8.2.tgz",
-      "integrity": "sha512-EGwzEeCcLniFX51DhTpmTom+dSA/MG/OBUDjnWtHbEnjAH180VzUeAw+oE4+Zv+CoYBWyRlYOTR0N8SO9R1PVw==",
-      "optional": true,
-      "bin": {
-        "marked": "bin/marked"
-      },
-      "engines": {
-        "node": ">= 8.16.2"
-      }
-    },
     "node_modules/md5.js": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
@@ -3863,12 +3732,6 @@
         "inherits": "^2.0.1",
         "safe-buffer": "^5.1.2"
       }
-    },
-    "node_modules/mdurl": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
-      "integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=",
-      "optional": true
     },
     "node_modules/media-typer": {
       "version": "0.3.0",
@@ -4264,33 +4127,21 @@
       }
     },
     "node_modules/node-zookeeper-client": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/node-zookeeper-client/-/node-zookeeper-client-0.2.3.tgz",
-      "integrity": "sha512-V4gVHxzQ42iwhkANpPryzfjmqi3Ql3xeO9E/px7W5Yi774WplU3YtqUpnvcL/eJit4UqcfuLOgZLkpf0BPhHmg==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/node-zookeeper-client/-/node-zookeeper-client-1.1.3.tgz",
+      "integrity": "sha512-S7DWrIpr16E03LSTbiuahcHvE/Aj3AJEh2X7+bL8sx/PoR8YNwUQlVspX1QslkD5Pk9RsC8ZTMN2GapS8IrOYQ==",
       "dependencies": {
-        "async": "~0.2.7",
-        "underscore": "~1.4.4"
+        "async": "~3.2.3",
+        "underscore": "~1.13.3"
       },
       "engines": {
-        "node": ">=0.6.0"
-      }
-    },
-    "node_modules/node-zookeeper-client-async": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-zookeeper-client-async/-/node-zookeeper-client-async-1.0.0.tgz",
-      "integrity": "sha512-h2rrxDxK7JMnZkvG90Dodo5Iu0o3ZntqlJLIUJw4shSxDdOoXCMi7Wb6w/sfl1fON9bO4wQptORyFfWnvjKpuw==",
-      "dependencies": {
-        "node-zookeeper-client": "^0.2.2"
-      },
-      "optionalDependencies": {
-        "bluebird": "^3.5.0",
-        "jsdoc": "^3.4.3"
+        "node": ">=8.10.0"
       }
     },
     "node_modules/node-zookeeper-client/node_modules/underscore": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz",
-      "integrity": "sha1-YaajIBBiKvoHljvzJSA88SI51gQ="
+      "version": "1.13.6",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.6.tgz",
+      "integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A=="
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -4902,15 +4753,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/requizzle": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.3.tgz",
-      "integrity": "sha512-YanoyJjykPxGHii0fZP0uUPEXpvqfBDxWV7s6GKAiiOsiqhX6vHNyW3Qzdmqp/iq/ExbhaGbVrjB4ruEVSM4GQ==",
-      "optional": true,
-      "dependencies": {
-        "lodash": "^4.17.14"
       }
     },
     "node_modules/resolve-alpn": {
@@ -5560,7 +5402,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/sshpk": {
       "version": "1.16.1",
@@ -5676,7 +5518,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-      "devOptional": true,
+      "dev": true,
       "engines": {
         "node": ">=8"
       },
@@ -5818,12 +5660,6 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true
-    },
-    "node_modules/taffydb": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/taffydb/-/taffydb-2.6.2.tgz",
-      "integrity": "sha1-fLy2S1oUG2ou/CxdLGe04VCyomg=",
-      "optional": true
     },
     "node_modules/tar": {
       "version": "4.4.19",
@@ -6022,12 +5858,6 @@
       "resolved": "https://registry.npmjs.org/typeforce/-/typeforce-1.18.0.tgz",
       "integrity": "sha512-7uc1O8h1M1g0rArakJdf0uLRSSgFcYexrVoKo+bzJd32gd4gDy2L/Z+8/FjPnU9ydY3pEnVPtr9FyscYY60K1g=="
     },
-    "node_modules/uc.micro": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
-      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
-      "optional": true
-    },
     "node_modules/ultron": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
@@ -6046,12 +5876,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/underscore": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.10.2.tgz",
-      "integrity": "sha512-N4P+Q/BuyuEKFJ43B9gYuOj4TQUHXX+j2FqguVOpjkssLUUrnJofCcBccJSCoeturDoZU6GorDTHSvUDlSQbTg==",
-      "optional": true
     },
     "node_modules/universalify": {
       "version": "0.1.2",
@@ -6919,12 +6743,6 @@
         "cookiejar": "^2.1.1"
       }
     },
-    "node_modules/xmlcreate": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/xmlcreate/-/xmlcreate-2.0.3.tgz",
-      "integrity": "sha512-HgS+X6zAztGa9zIK3Y3LXuJes33Lz9x+YyTxgrkIdabu2vqcGOWwdfCpf1hWLRrd553wd4QCDf6BBO6FfdsRiQ==",
-      "optional": true
-    },
     "node_modules/xrpl": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/xrpl/-/xrpl-2.6.0.tgz",
@@ -7134,12 +6952,6 @@
           }
         }
       }
-    },
-    "@babel/parser": {
-      "version": "7.13.16",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.16.tgz",
-      "integrity": "sha512-6bAg36mCwuqLO0hbR+z7PHuqWiCeP7Dzg73OpQwsAB1Eb8HnGEz5xYBzCfbu+YjoaJsJs+qheDxVAuqbt3ILEw==",
-      "optional": true
     },
     "@eslint/eslintrc": {
       "version": "1.3.3",
@@ -7609,7 +7421,7 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "sprintf-js": "~1.0.2"
       }
@@ -7666,9 +7478,9 @@
       "dev": true
     },
     "async": {
-      "version": "0.2.10",
-      "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-      "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E="
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
+      "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ=="
     },
     "async-limiter": {
       "version": "1.0.1",
@@ -8095,15 +7907,6 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
-    },
-    "catharsis": {
-      "version": "0.8.11",
-      "resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.8.11.tgz",
-      "integrity": "sha512-a+xUyMV7hD1BrDQA/3iPV7oc+6W26BgVJO05PGEoatMyIuPScQKsde6i3YorWX1qs+AZjnJ18NqdKoCtKiNh1g==",
-      "optional": true,
-      "requires": {
-        "lodash": "^4.17.14"
-      }
     },
     "chalk": {
       "version": "4.1.1",
@@ -8541,12 +8344,6 @@
       "requires": {
         "ansi-colors": "^4.1.1"
       }
-    },
-    "entities": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.3.tgz",
-      "integrity": "sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ==",
-      "optional": true
     },
     "es-abstract": {
       "version": "1.18.0",
@@ -9768,49 +9565,10 @@
         }
       }
     },
-    "js2xmlparser": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/js2xmlparser/-/js2xmlparser-4.0.1.tgz",
-      "integrity": "sha512-KrPTolcw6RocpYjdC7pL7v62e55q7qOMHvLX1UCLc5AAS8qeJ6nukarEJAF2KL2PZxlbGueEbINqZR2bDe/gUw==",
-      "optional": true,
-      "requires": {
-        "xmlcreate": "^2.0.3"
-      }
-    },
     "jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
-    },
-    "jsdoc": {
-      "version": "3.6.6",
-      "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.6.6.tgz",
-      "integrity": "sha512-znR99e1BHeyEkSvgDDpX0sTiTu+8aQyDl9DawrkOGZTTW8hv0deIFXx87114zJ7gRaDZKVQD/4tr1ifmJp9xhQ==",
-      "optional": true,
-      "requires": {
-        "@babel/parser": "^7.9.4",
-        "bluebird": "^3.7.2",
-        "catharsis": "^0.8.11",
-        "escape-string-regexp": "^2.0.0",
-        "js2xmlparser": "^4.0.1",
-        "klaw": "^3.0.0",
-        "markdown-it": "^10.0.0",
-        "markdown-it-anchor": "^5.2.7",
-        "marked": "^0.8.2",
-        "mkdirp": "^1.0.4",
-        "requizzle": "^0.2.3",
-        "strip-json-comments": "^3.1.0",
-        "taffydb": "2.6.2",
-        "underscore": "~1.10.2"
-      },
-      "dependencies": {
-        "escape-string-regexp": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
-          "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
-          "optional": true
-        }
-      }
     },
     "json-buffer": {
       "version": "3.0.1",
@@ -9888,15 +9646,6 @@
         "json-buffer": "3.0.1"
       }
     },
-    "klaw": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/klaw/-/klaw-3.0.0.tgz",
-      "integrity": "sha512-0Fo5oir+O9jnXu5EefYbVK+mHMBeEVEy2cmctR1O1NECcCkPRreJKrS6Qt/j3KC2C148Dfo9i3pCmCMsdqGr0g==",
-      "optional": true,
-      "requires": {
-        "graceful-fs": "^4.1.9"
-      }
-    },
     "levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -9905,15 +9654,6 @@
       "requires": {
         "prelude-ls": "^1.2.1",
         "type-check": "~0.4.0"
-      }
-    },
-    "linkify-it": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.2.0.tgz",
-      "integrity": "sha512-GnAl/knGn+i1U/wjBz3akz2stz+HrHLsxMwHQGofCDfPvlf+gDKN58UtfmUquTY4/MXeE2x7k19KQmeoZi94Iw==",
-      "optional": true,
-      "requires": {
-        "uc.micro": "^1.0.1"
       }
     },
     "locate-path": {
@@ -9966,32 +9706,6 @@
         "yallist": "^4.0.0"
       }
     },
-    "markdown-it": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-10.0.0.tgz",
-      "integrity": "sha512-YWOP1j7UbDNz+TumYP1kpwnP0aEa711cJjrAQrzd0UXlbJfc5aAq0F/PZHjiioqDC1NKgvIMX+o+9Bk7yuM2dg==",
-      "optional": true,
-      "requires": {
-        "argparse": "^1.0.7",
-        "entities": "~2.0.0",
-        "linkify-it": "^2.0.0",
-        "mdurl": "^1.0.1",
-        "uc.micro": "^1.0.5"
-      }
-    },
-    "markdown-it-anchor": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-5.3.0.tgz",
-      "integrity": "sha512-/V1MnLL/rgJ3jkMWo84UR+K+jF1cxNG1a+KwqeXqTIJ+jtA8aWSHuigx8lTzauiIjBDbwF3NcWQMotd0Dm39jA==",
-      "optional": true,
-      "requires": {}
-    },
-    "marked": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.8.2.tgz",
-      "integrity": "sha512-EGwzEeCcLniFX51DhTpmTom+dSA/MG/OBUDjnWtHbEnjAH180VzUeAw+oE4+Zv+CoYBWyRlYOTR0N8SO9R1PVw==",
-      "optional": true
-    },
     "md5.js": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
@@ -10001,12 +9715,6 @@
         "inherits": "^2.0.1",
         "safe-buffer": "^5.1.2"
       }
-    },
-    "mdurl": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
-      "integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=",
-      "optional": true
     },
     "media-typer": {
       "version": "0.3.0",
@@ -10320,29 +10028,19 @@
       }
     },
     "node-zookeeper-client": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/node-zookeeper-client/-/node-zookeeper-client-0.2.3.tgz",
-      "integrity": "sha512-V4gVHxzQ42iwhkANpPryzfjmqi3Ql3xeO9E/px7W5Yi774WplU3YtqUpnvcL/eJit4UqcfuLOgZLkpf0BPhHmg==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/node-zookeeper-client/-/node-zookeeper-client-1.1.3.tgz",
+      "integrity": "sha512-S7DWrIpr16E03LSTbiuahcHvE/Aj3AJEh2X7+bL8sx/PoR8YNwUQlVspX1QslkD5Pk9RsC8ZTMN2GapS8IrOYQ==",
       "requires": {
-        "async": "~0.2.7",
-        "underscore": "~1.4.4"
+        "async": "~3.2.3",
+        "underscore": "~1.13.3"
       },
       "dependencies": {
         "underscore": {
-          "version": "1.4.4",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz",
-          "integrity": "sha1-YaajIBBiKvoHljvzJSA88SI51gQ="
+          "version": "1.13.6",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.6.tgz",
+          "integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A=="
         }
-      }
-    },
-    "node-zookeeper-client-async": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-zookeeper-client-async/-/node-zookeeper-client-async-1.0.0.tgz",
-      "integrity": "sha512-h2rrxDxK7JMnZkvG90Dodo5Iu0o3ZntqlJLIUJw4shSxDdOoXCMi7Wb6w/sfl1fON9bO4wQptORyFfWnvjKpuw==",
-      "requires": {
-        "bluebird": "^3.5.0",
-        "jsdoc": "^3.4.3",
-        "node-zookeeper-client": "^0.2.2"
       }
     },
     "normalize-path": {
@@ -10784,15 +10482,6 @@
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "dev": true
-    },
-    "requizzle": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.3.tgz",
-      "integrity": "sha512-YanoyJjykPxGHii0fZP0uUPEXpvqfBDxWV7s6GKAiiOsiqhX6vHNyW3Qzdmqp/iq/ExbhaGbVrjB4ruEVSM4GQ==",
-      "optional": true,
-      "requires": {
-        "lodash": "^4.17.14"
-      }
     },
     "resolve-alpn": {
       "version": "1.2.0",
@@ -11292,7 +10981,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-      "devOptional": true
+      "dev": true
     },
     "sshpk": {
       "version": "1.16.1",
@@ -11378,7 +11067,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-      "devOptional": true
+      "dev": true
     },
     "supports-color": {
       "version": "7.2.0",
@@ -11490,12 +11179,6 @@
           "dev": true
         }
       }
-    },
-    "taffydb": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/taffydb/-/taffydb-2.6.2.tgz",
-      "integrity": "sha1-fLy2S1oUG2ou/CxdLGe04VCyomg=",
-      "optional": true
     },
     "tar": {
       "version": "4.4.19",
@@ -11653,12 +11336,6 @@
       "resolved": "https://registry.npmjs.org/typeforce/-/typeforce-1.18.0.tgz",
       "integrity": "sha512-7uc1O8h1M1g0rArakJdf0uLRSSgFcYexrVoKo+bzJd32gd4gDy2L/Z+8/FjPnU9ydY3pEnVPtr9FyscYY60K1g=="
     },
-    "uc.micro": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
-      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
-      "optional": true
-    },
     "ultron": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
@@ -11674,12 +11351,6 @@
         "has-symbols": "^1.0.2",
         "which-boxed-primitive": "^1.0.2"
       }
-    },
-    "underscore": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.10.2.tgz",
-      "integrity": "sha512-N4P+Q/BuyuEKFJ43B9gYuOj4TQUHXX+j2FqguVOpjkssLUUrnJofCcBccJSCoeturDoZU6GorDTHSvUDlSQbTg==",
-      "optional": true
     },
     "universalify": {
       "version": "0.1.2",
@@ -12429,12 +12100,6 @@
       "requires": {
         "cookiejar": "^2.1.1"
       }
-    },
-    "xmlcreate": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/xmlcreate/-/xmlcreate-2.0.3.tgz",
-      "integrity": "sha512-HgS+X6zAztGa9zIK3Y3LXuJes33Lz9x+YyTxgrkIdabu2vqcGOWwdfCpf1hWLRrd553wd4QCDf6BBO6FfdsRiQ==",
-      "optional": true
     },
     "xrpl": {
       "version": "2.6.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "micro": "^9.3.4",
     "node-json-logger": "^0.0.17",
     "node-rdkafka": "2.12.0",
-    "node-zookeeper-client-async": "^1.0.0",
+    "node-zookeeper-client": "^1.1.3",
     "p-queue": "^7.2.0",
     "prom-client": "^13.1.0",
     "segfault-handler": "^1.3.0",


### PR DESCRIPTION
The project [zookeeper-client-async](https://github.com/cilliemalan/node-zookeeper-client-async/blob/master/index.js) seems to be abandoned, there are old PRs which update the dependency to the parent project which are not merged. In this PR we start depending on the [parent project](https://github.com/alexguan/node-zookeeper-client), but still wrap it in Promises. Basically I have copied the code we need from the async version.