### PR TITLE
Handle a trace where 'action' is null

### DIFF
--- a/blockchains/eth/eth_worker.js
+++ b/blockchains/eth/eth_worker.js
@@ -23,20 +23,22 @@ class ETHWorker extends BaseWorker {
     this.feesDecoder = new FeesDecoder(this.web3, this.web3Wrapper);
   }
 
+  parseEthInternalTrx(result) {
+    const traces = filterErrors(result);
+
+    return traces
+      .filter((trace) =>
+        trace['action']['value'] !== '0x0' &&
+        trace['action']['balance'] !== '0x0' &&
+        !(trace['type'] === 'call' && trace['action']['callType'] !== 'call')
+      );
+  }
+
   fetchEthInternalTrx(fromBlock, toBlock) {
     return this.ethClient.request('trace_filter', [{
       fromBlock: this.web3Wrapper.parseNumberToHex(fromBlock),
       toBlock: this.web3Wrapper.parseNumberToHex(toBlock)
-    }]).then((data) => {
-      const traces = filterErrors(data['result']);
-
-      return traces
-        .filter((trace) =>
-          trace['action']['value'] !== '0x0' &&
-          trace['action']['balance'] !== '0x0' &&
-          !(trace['type'] === 'call' && trace['action']['callType'] !== 'call')
-        );
-    });
+    }]).then((data) => this.parseEthInternalTrx(data['result']));
   }
 
   async fetchBlocks(fromBlock, toBlock) {

--- a/blockchains/eth/lib/filter_errors.js
+++ b/blockchains/eth/lib/filter_errors.js
@@ -45,7 +45,8 @@ function setErrors(traces) {
  }
 */
 function filterNonActions(traces) {
-  return traces.filter(trace => typeof trace.action !== 'undefined');
+  // Leave only 'truthy' action values
+  return traces.filter(trace => trace.action);
 }
 
 function filterErrors(traces) {

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -37,7 +37,7 @@ COPY package.json AUTHORS LICENSE index.js /opt/app/
 COPY blockchains /opt/app/blockchains
 COPY lib/ /opt/app/lib
 COPY test /opt/app/test
-COPY docker/wait_for_services.sh /opt/app/docker
+COPY docker/wait_for_services.sh /opt/app/docker/wait_for_services.sh
 
 EXPOSE 3000
 

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -26,6 +26,8 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
     logging:
       driver: none
+    depends_on:
+      - zookeeper
   exporter:
     build:
       context: ../

--- a/test/eth/test_action_null.json
+++ b/test/eth/test_action_null.json
@@ -1,0 +1,19 @@
+[
+  {
+    "action": null,
+    "blockHash": "0xfebdb7331dcd410b90d3394b3f42f99b8df88134b1ffcf4589e2e08bbe5da5c0",
+    "blockNumber": 16375524,
+    "result": {
+      "gasUsed": "0x0",
+      "output": "0x"
+    },
+    "subtraces": 0,
+    "traceAddress": [
+      0,
+      2
+    ],
+    "transactionHash": "0x95d801b07418a591b94f6029831b73a73d534e00ea4e1effc3c30f00832dcf31",
+    "transactionPosition": 75,
+    "type": "call"
+  }
+]

--- a/test/eth/worker.spec.js
+++ b/test/eth/worker.spec.js
@@ -1,15 +1,17 @@
-const eth_worker =  require('../../blockchains/eth/eth_worker');
+const eth_worker = require('../../blockchains/eth/eth_worker');
 const assert = require('assert');
 const v8 = require('v8');
 
-describe('Test worker', function() {
+const testNullAction = require('./test_action_null.json');
+
+describe('Test worker', function () {
     const worker = new eth_worker.worker();
     let feeResult = null;
     let callResult = null;
     let feeResultWithPrimaryKey = null;
     let callResultWithPrimaryKey = null;
 
-    beforeEach(function() {
+    beforeEach(function () {
         feeResult = {
             from: '0x03b16ab6e23bdbeeab719d8e4c49d63674876253',
             to: '0x829bd824b016326a401d083b33d092293333a830',
@@ -57,4 +59,13 @@ describe('Test worker', function() {
         assert.deepStrictEqual(result, [feeResultWithPrimaryKey, callResultWithPrimaryKey]);
     });
 
+});
+
+describe('Test that when action is null parsing would not break', function () {
+    it('Null action should not break parsing', function () {
+        const worker = new eth_worker.worker();
+        const result = worker.parseEthInternalTrx(testNullAction);
+
+        assert.deepStrictEqual(result, []);
+    });
 });


### PR DESCRIPTION
A fix for a case where ETH node returns trace containing
```json
{
  "action": null
}
```

this has happened in Erigon v2.33.0