### PR TITLE
Add eth beacon chain withdrawals

### DIFF
--- a/blockchains/eth/lib/constants.js
+++ b/blockchains/eth/lib/constants.js
@@ -3,8 +3,10 @@ const CONFIRMATIONS = parseInt(process.env.CONFIRMATIONS || '3');
 const NODE_URL = process.env.NODE_URL || process.env.PARITY_URL || 'http://localhost:8545/';
 const LOOP_INTERVAL_CURRENT_MODE_SEC = parseInt(process.env.LOOP_INTERVAL_CURRENT_MODE_SEC || '30');
 const BURN_ADDRESS = 'burn';
+const ETH_WITHDRAWAL = 'withdrawal'
 const IS_ETH = parseInt(process.env.IS_ETH || '1');
 const LONDON_FORK_BLOCK = 12965000;
+const SHANGHAI_FORK_BLOCK = 17034871;
 // This is the API method that Parity provides for fetching receipts across multiple blocks. Erigon instead provides
 // a method called 'eth_getBlockReceipts'. If we are deploying against Erigon, we need to overwrite this variable
 // through the deploy.
@@ -18,5 +20,6 @@ module.exports = {
     BURN_ADDRESS,
     IS_ETH,
     LONDON_FORK_BLOCK,
+    SHANGHAI_FORK_BLOCK,
     RECEIPTS_API_METHOD
 };

--- a/blockchains/eth/lib/withdrawals_decoder.js
+++ b/blockchains/eth/lib/withdrawals_decoder.js
@@ -1,0 +1,38 @@
+const { computeGasExpense, computeGasExpenseBase36 } = require('./util');
+const constants = require('./constants');
+
+class WithdrawalsDecoder {
+  constructor(web3, web3Wrapper) {
+    this.web3 = web3;
+    this.web3Wrapper = web3Wrapper;
+  }
+
+  getWithdrawal(withdrawal, block, blockNumber) {
+    // Node returns value of withdrawal in gwei (10^-9) so we have to multiply it by 10^9
+    const gwei_to_wei = Math.pow(10, 9);
+    return [{
+      from: constants.ETH_WITHDRAWAL,
+      to: withdrawal.address,
+      value: this.web3Wrapper.parseHexToNumber(withdrawal.amount) * gwei_to_wei,
+      valueExactBase36: this.web3Wrapper.parseValueToBN(withdrawal.amount).mul(this.web3.utils.toBN(gwei_to_wei.toString())).toString(36),
+      blockNumber: blockNumber,
+      timestamp: this.web3Wrapper.parseHexToNumber(block.timestamp),
+      transactionHash: `WITHDRAWAL_${blockNumber}`,
+      type: 'beacon_withdrawal'
+    }];
+  }
+
+
+  getBeaconChainWithdrawals(block, blockNumber) {
+    const result = [];
+    block.withdrawals.forEach((withdrawal) => {
+      const withdrawalTransfer = this.getWithdrawal(withdrawal, block, blockNumber);
+      result.push(...withdrawalTransfer);
+    });
+    return result;
+  }
+}
+
+module.exports = {
+  WithdrawalsDecoder
+};


### PR DESCRIPTION
All rewards that the validator node earns are withdrawn automatically if the validator has set his withdrawal address. Our current exporter does not export such events.
After block 17034871 (included) `eth_getBlockByNumber` returns `withdrawals` array that look like this

```
[
      {
        "index": "0x25d",
        "validatorIndex": "0x25dd6",
        "address": "0x540d5ca1b42ddbfa895a9cf64dd72db9775223d2",
        "amount": "0xb0a969e6"
      },
      {
        "index": "0x25e",
        "validatorIndex": "0x25dd7",
        "address": "0x540d5ca1b42ddbfa895a9cf64dd72db9775223d2",
        "amount": "0xaec66b54"
      },
....
]
```

Here we can track: https://etherscan.io/txsBeaconWithdrawal