### PR TITLE
When init position from START_BLOCK substract 1

### DIFF
--- a/lib/worker_base.js
+++ b/lib/worker_base.js
@@ -59,7 +59,7 @@ class WorkerBase {
       logger.info(`Resuming export from position ${JSON.stringify(lastProcessedPosition)}`);
     } else {
       lastProcessedPosition = {
-        blockNumber: parseInt(process.env.START_BLOCK || '-1'),
+        blockNumber: parseInt(process.env.START_BLOCK || '0') - 1,
         primaryKey: parseInt(process.env.START_PRIMARY_KEY || '-1')
       };
       logger.info(`Initialized exporter with initial position ${JSON.stringify(lastProcessedPosition)}`);


### PR DESCRIPTION
If we use the START_BLOCK Env variable to start the exporter from a particular position, we should substract 1. Reason is that we use this value as 'last processed', so the first block we extract would be this value plus 1. Example: If we set START_BLOCK=100 first extracted up until now would be 101, while we would expect it to be 100.