### PR TITLE
Correctly read concurrency variable in utxo exporter

### DIFF
--- a/blockchains/utxo/lib/constants.js
+++ b/blockchains/utxo/lib/constants.js
@@ -1,4 +1,4 @@
-const SEND_BATCH_SIZE = parseInt(process.env.SEND_BATCH_SIZE || '10');
+const MAX_CONCURRENT_REQUESTS = parseInt(process.env.MAX_CONCURRENT_REQUESTS || '10');
 const DEFAULT_TIMEOUT = parseInt(process.env.DEFAULT_TIMEOUT || '10000');
 const CONFIRMATIONS = parseInt(process.env.CONFIRMATIONS || '3');
 const NODE_URL = process.env.NODE_URL || 'http://litecoin.stage.san:30992';
@@ -9,7 +9,7 @@ const LOOP_INTERVAL_CURRENT_MODE_SEC = parseInt(process.env.LOOP_INTERVAL_CURREN
 const DOGE = process.env.DOGE || 0;
 
 module.exports = {
-  SEND_BATCH_SIZE,
+  MAX_CONCURRENT_REQUESTS,
   DEFAULT_TIMEOUT,
   CONFIRMATIONS,
   RPC_USERNAME,

--- a/blockchains/utxo/utxo_worker.js
+++ b/blockchains/utxo/utxo_worker.js
@@ -11,7 +11,7 @@ const {
   DOGE,
   CONFIRMATIONS,
   LOOP_INTERVAL_CURRENT_MODE_SEC,
-  SEND_BATCH_SIZE
+  MAX_CONCURRENT_REQUESTS
 } = require('./lib/constants');
 const URL = parseURL(NODE_URL);
 
@@ -94,7 +94,7 @@ class UtxoWorker extends BaseWorker {
 
       requests.push(this.fetchBlock(blockToDownload));
 
-      if (blockToDownload >= this.lastConfirmedBlock || requests.length >= SEND_BATCH_SIZE) {
+      if (blockToDownload >= this.lastConfirmedBlock || requests.length >= MAX_CONCURRENT_REQUESTS) {
         const blocks = await Promise.all(requests);
         this.lastExportedBlock = blockToDownload;
         logger.info(`Flushing blocks ${blocks[0].height}:${blocks[blocks.length - 1].height}`);

--- a/blockchains/utxo/utxo_worker.js
+++ b/blockchains/utxo/utxo_worker.js
@@ -94,7 +94,7 @@ class UtxoWorker extends BaseWorker {
 
       requests.push(this.fetchBlock(blockToDownload));
 
-      if (blockToDownload >= this.lastConfirmedBlock || requests.length > SEND_BATCH_SIZE) {
+      if (blockToDownload >= this.lastConfirmedBlock || requests.length >= SEND_BATCH_SIZE) {
         const blocks = await Promise.all(requests);
         this.lastExportedBlock = blockToDownload;
         logger.info(`Flushing blocks ${blocks[0].height}:${blocks[blocks.length - 1].height}`);


### PR DESCRIPTION
In this PR:
* Change the env variable used from SEND_BATCH_SIZE to MAX_CONCURRENT_REQUESTS. I see old UTXO exporter uses both, I think the second is more descriptive.
* Changing `requests.length > SEND_BATCH_SIZE` to  `requests.length >= SEND_BATCH_SIZE`. If we set the Env variable to 1 we want to have 1 connection and not 2.
* Ability to stop exporter by pressing Ctrl+C twice