### PR TITLE
Simplify UTXO exporter work loop

### DIFF
--- a/blockchains/utxo/utxo_worker.js
+++ b/blockchains/utxo/utxo_worker.js
@@ -89,8 +89,8 @@ class UtxoWorker extends BaseWorker {
 
     const requests = [];
 
-    while (this.lastExportedBlock + requests.length <= this.lastConfirmedBlock) {
-      const blockToDownload = this.lastExportedBlock + requests.length;
+    while (this.lastExportedBlock + requests.length + 1 <= this.lastConfirmedBlock) {
+      const blockToDownload = this.lastExportedBlock + requests.length + 1;
 
       requests.push(this.fetchBlock(blockToDownload));
 

--- a/blockchains/utxo/utxo_worker.js
+++ b/blockchains/utxo/utxo_worker.js
@@ -87,20 +87,11 @@ class UtxoWorker extends BaseWorker {
       this.sleepTimeMsec = 0;
     }
 
-    const requests = [];
-
-    while (this.lastExportedBlock + requests.length + 1 <= this.lastConfirmedBlock) {
-      const blockToDownload = this.lastExportedBlock + requests.length + 1;
-
-      requests.push(this.fetchBlock(blockToDownload));
-
-      if (blockToDownload >= this.lastConfirmedBlock || requests.length >= MAX_CONCURRENT_REQUESTS) {
-        const blocks = await Promise.all(requests);
-        this.lastExportedBlock = blockToDownload;
-        logger.info(`Flushing blocks ${blocks[0].height}:${blocks[blocks.length - 1].height}`);
-        return blocks;
-      }
-    }
+    const numConcurrentRequests = Math.min(MAX_CONCURRENT_REQUESTS, this.lastConfirmedBlock - this.lastExportedBlock);
+    const requests = Array.from({ numConcurrentRequests }, (_, i) => this.fetchBlock(this.lastExportedBlock + i));
+    const blocks = await Promise.all(requests);
+    this.lastExportedBlock += blocks.length;
+    return blocks;
   }
 }
 

--- a/blockchains/utxo/utxo_worker.js
+++ b/blockchains/utxo/utxo_worker.js
@@ -88,7 +88,7 @@ class UtxoWorker extends BaseWorker {
     }
 
     const numConcurrentRequests = Math.min(MAX_CONCURRENT_REQUESTS, this.lastConfirmedBlock - this.lastExportedBlock);
-    const requests = Array.from({ numConcurrentRequests }, (_, i) => this.fetchBlock(this.lastExportedBlock + i));
+    const requests = Array.from({ length: numConcurrentRequests }, (_, i) => this.fetchBlock(this.lastExportedBlock + i));
     const blocks = await Promise.all(requests);
     this.lastExportedBlock += blocks.length;
     return blocks;


### PR DESCRIPTION
I think this loop inside the worker function is way too complicated with no benefit. When having a huge gap to close to the blockchain head the previous implementation would stay in `work()` way too long. We have some maintenance work to be done down the stack, like updating metrics and logging, so there is no benefit in keeping the thread that long.