### PR TITLE
Tweaking block number for UTXO

### DIFF
--- a/blockchains/utxo/utxo_worker.js
+++ b/blockchains/utxo/utxo_worker.js
@@ -88,7 +88,7 @@ class UtxoWorker extends BaseWorker {
     }
 
     const numConcurrentRequests = Math.min(MAX_CONCURRENT_REQUESTS, this.lastConfirmedBlock - this.lastExportedBlock);
-    const requests = Array.from({ length: numConcurrentRequests }, (_, i) => this.fetchBlock(this.lastExportedBlock + i));
+    const requests = Array.from({ length: numConcurrentRequests }, (_, i) => this.fetchBlock(this.lastExportedBlock + i + 1));
     const blocks = await Promise.all(requests);
     this.lastExportedBlock += blocks.length;
     return blocks;


### PR DESCRIPTION
Adding a '+1' to the scraping process, because we've made the START_BLOCK to be -1 at the beginning and the utxo worker would make an initial array of [-1,0,1...], whilst -1 is an invalid block number