### PR TITLE
Implement a retry logic in the XRP exporter

### DIFF
--- a/blockchains/xrp/lib/constants.js
+++ b/blockchains/xrp/lib/constants.js
@@ -9,6 +9,7 @@ const MAX_CONNECTION_CONCURRENCY = parseInt(process.env.MAX_CONNECTION_CONCURREN
 const XRP_NODE_URLS = process.env.XRP_NODE_URLS || 'wss://s2.ripple.com';
 const EXPORT_TIMEOUT_MLS = parseInt(process.env.EXPORT_TIMEOUT_MLS || 1000 * 60 * 5);
 const LOOP_INTERVAL_CURRENT_MODE_SEC = parseInt(process.env.LOOP_INTERVAL_CURRENT_MODE_SEC || '30');
+const XRP_ENDPOINT_RETRIES = parseInt(process.env.XRP_ENDPOINT_RETIRES || '100');
 
 module.exports = {
   SEND_BATCH_SIZE,
@@ -18,5 +19,6 @@ module.exports = {
   XRP_NODE_URLS,
   EXPORT_TIMEOUT_MLS,
   CONFIRMATIONS,
-  LOOP_INTERVAL_CURRENT_MODE_SEC
+  LOOP_INTERVAL_CURRENT_MODE_SEC,
+  XRP_ENDPOINT_RETRIES
 };

--- a/blockchains/xrp/xrp_worker.js
+++ b/blockchains/xrp/xrp_worker.js
@@ -10,7 +10,6 @@ class XRPWorker extends BaseWorker {
     super();
     this.nodeURLs = constants.XRP_NODE_URLS.split(',');
     this.connections = [];
-    this.emptyBlock = { ledger: { transactions: [] }};
     this.emptyTransactionHash = '0000000000000000000000000000000000000000000000000000000000000000';
     this.retryIntervalMs = 1000;
   }

--- a/blockchains/xrp/xrp_worker.js
+++ b/blockchains/xrp/xrp_worker.js
@@ -55,12 +55,14 @@ class XRPWorker extends BaseWorker {
   }
 
   async fetchLedger(connection, ledger_index, should_expand) {
-    const ledger = await this.connectionSend(connection, {
+    const result = await this.connectionSend(connection, {
       command: 'ledger',
       ledger_index: parseInt(ledger_index),
       transactions: true,
       expand: should_expand
-    }).then(value => value.result.ledger);
+    });
+
+    const ledger = result.result.ledger;
 
     assert(ledger.closed === true);
     assert(typeof ledger.transactions !== 'undefined');

--- a/test/xrp/worker.test.js
+++ b/test/xrp/worker.test.js
@@ -96,7 +96,7 @@ describe('workLoopSimpleTest', function () {
         ledger: {
           transactions: [],
           closed: true,
-          transaction_hash: worker.emptyTransactionHash
+          transaction_hash: '0'.repeat(64)
         }
       }
     };
@@ -113,7 +113,7 @@ describe('workLoopSimpleTest', function () {
     let sendCallsCountWhileInvalid = 0;
     // After a timeout, switch the mock function to return the vadlic block. Remember how many calls were made up until that moment.
     setTimeout(() => {
-    sendCallsCountWhileInvalid = sendCallsCount;
+      sendCallsCountWhileInvalid = sendCallsCount;
       worker.connectionSend = () => {
         sendCallsCount += 1;
         return Promise.resolve(validEmptyBlock);
@@ -125,6 +125,6 @@ describe('workLoopSimpleTest', function () {
 
     assert.ok(sendCallsCountWhileInvalid >= 2);
     assert.ok(sendCallsCount >= 3);
-    assert.deepStrictEqual(fetchResult, {ledger: validEmptyBlock.result.ledger, transactions: []});
+    assert.deepStrictEqual(fetchResult, { ledger: validEmptyBlock.result.ledger, transactions: [] });
   });
 });

--- a/test/xrp/worker.test.js
+++ b/test/xrp/worker.test.js
@@ -79,4 +79,52 @@ describe('workLoopSimpleTest', function () {
     assert.deepStrictEqual(result, expectedResult);
   });
 
+  it('should loop several times due to lack of transactions', async () => {
+    const worker = new xrp_worker.worker();
+    // The invalid block would have no transactions but a non 0 transaction_hash
+    const invalidBlock = {
+      result: {
+        ledger: {
+          transactions: [],
+          closed: true,
+          transaction_hash: "1111111111111"
+        }
+      }
+    };
+    const validEmptyBlock = {
+      result: {
+        ledger: {
+          transactions: [],
+          closed: true,
+          transaction_hash: worker.emptyTransactionHash
+        }
+      }
+    };
+
+    // We mock the connection send call and count how many times it is called
+    let sendCallsCount = 0;
+    // Reduce the retry interval so that tests finishes fast
+    worker.retryIntervalMs = 100;
+    worker.connectionSend = () => {
+      sendCallsCount += 1;
+      return Promise.resolve(invalidBlock);
+    };
+
+    let sendCallsCountWhileInvalid = 0;
+    // After a timeout, switch the mock function to return the vadlic block. Remember how many calls were made up until that moment.
+    setTimeout(() => {
+    sendCallsCountWhileInvalid = sendCallsCount;
+      worker.connectionSend = () => {
+        sendCallsCount += 1;
+        return Promise.resolve(validEmptyBlock);
+      };
+    }, 2 * worker.retryIntervalMs);
+
+    // This call should eventually return, once the callback returns the correct block
+    const fetchResult = await worker.fetchLedgerTransactions(null, 1)
+
+    assert.ok(sendCallsCountWhileInvalid >= 2);
+    assert.ok(sendCallsCount >= 3);
+    assert.deepStrictEqual(fetchResult, {ledger: validEmptyBlock.result.ledger, transactions: []});
+  });
 });


### PR DESCRIPTION
Sometimes the XRP endpoint would return an empty block. We are able to identify this by a non-0 `transaction_hash` field. In such case we can retry.