### PR TITLE
Capture SIGTERM signal coming from Kubernetes

### DIFF
--- a/bin/export_env_vars.sh
+++ b/bin/export_env_vars.sh
@@ -1,6 +1,6 @@
-export KAFKA_URL=localhost:9092
-export ZOOKEEPER_URL=localhost:2181
-export NODE_URL=http://erigon-hz.stage.san:30250
+export KAFKA_URL=kafka-hz.stage.san:30911
+export ZOOKEEPER_URL=zookeeper-hz.stage.san:30921
+export NODE_URL=https://ethereum.santiment.net
 export START_BLOCK="15676731"
 export BLOCK_INTERVAL="50"
 export EXPORT_TIMEOUT_MLS=300000

--- a/blockchains/xrp/xrp_worker.js
+++ b/blockchains/xrp/xrp_worker.js
@@ -19,11 +19,16 @@ class XRPWorker extends BaseWorker {
       throw 'Error: All API URLs returned error.';
     }
 
-    const nodeURL = this.nodeURLs.shift();
-    logger.info(`Using ${nodeURL} as XRPL API endpoint.`);
     for (let i = 0; i < constants.CONNECTIONS_COUNT; i++) {
       const clientOptions = { timeout: constants.DEFAULT_WS_TIMEOUT };
+      const nodeURL = this.nodeURLs[i % this.nodeURLs.length];
+      logger.info(`Using ${nodeURL} as XRPL API endpoint.`);
       const api = new xrpl.Client(nodeURL, clientOptions);
+
+      api.on('error', (...error) => {
+        logger.error('Error in XRPL API connection number: ' + i + error);
+        process.exit(-1);
+      });
       await api.connect();
 
       this.connections.push({

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -41,4 +41,4 @@ COPY docker/wait_for_services.sh /opt/app/docker/wait_for_services.sh
 
 EXPOSE 3000
 
-CMD npm start
+CMD ["node", "index.js"]

--- a/index.js
+++ b/index.js
@@ -38,6 +38,7 @@ class Main {
   }
 
   async disconnect() {
+    // This call should be refactored to work with async/await
     this.exporter.disconnect();
     await this.microServer.close();
   }

--- a/index.js
+++ b/index.js
@@ -143,6 +143,9 @@ main.init()
 process.on('SIGINT', () => {
   main.stop();
 });
+process.on('SIGTERM', () => {
+  main.stop();
+});
 
 
 const microHandler = async (request, response) => {

--- a/index.js
+++ b/index.js
@@ -66,6 +66,13 @@ class Main {
       }
       else {
         this.exporter.disconnect();
+        this.microServer.close(err => {
+          if (err) {
+            logger.error('Error stopping Micro server:', err);
+          } else {
+            console.log('Micro server has been stopped');
+          }
+        });
       }
     }
     catch (ex) {
@@ -135,7 +142,9 @@ main.init()
   }, (ex) => {
     console.error('Error initializing exporter: ', ex);
   })
-  .then(null, (ex) => {
+  .then(() => {
+    logger.info('Bye!');
+  }, (ex) => {
     console.error('Error in work loop: ', ex);
   });
 

--- a/package.json
+++ b/package.json
@@ -5,8 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "CONTRACT_MAPPING_FILE_PATH=test/erc20/contract_mapping/contract_mapping.json LOG_LEVEL=error CONTRACT_MODE=extract_exact_overwrite mocha --recursive --reporter spec",
-    "lint": "eslint '**/*.js'",
-    "start": "micro"
+    "lint": "eslint '**/*.js'"
   },
   "repository": {
     "type": "git",

--- a/test/xrp/worker.test.js
+++ b/test/xrp/worker.test.js
@@ -111,7 +111,7 @@ describe('workLoopSimpleTest', function () {
     };
 
     let sendCallsCountWhileInvalid = 0;
-    // After a timeout, switch the mock function to return the vadlic block. Remember how many calls were made up until that moment.
+    // After a timeout, switch the mock function to return the valid block. Remember how many calls were made up until that moment.
     setTimeout(() => {
       sendCallsCountWhileInvalid = sendCallsCount;
       worker.connectionSend = () => {


### PR DESCRIPTION
Up until now the container entrypoint looked like so:
```npm -> micro -> index.js```
this prevented the `SIGTERM` coming from Kubernetes to reach our `index.js` and allow for graceful stop. After reading on the topic I could not find a way how to propagate the signal besides changing the entry point to just:
```node index.js```

In this PR the above is implemented, this requires for the Micro service to be started and stopped explicitly. Also some refactoring to simplify the main program flow, now we `await` various method calls and know where exactly execution is, allowing to print 'Bye' at the user at the end to confirm exit.