### PR TITLE
Prevent Cardano from writing invalid lastExporedBlock

### DIFF
--- a/test/cardano/worker.spec.js
+++ b/test/cardano/worker.spec.js
@@ -210,16 +210,5 @@ describe('workLoopTest', function () {
     assert.deepStrictEqual(result, expected);
   });
 
-  it('test empty transactions would still move last exported marker forward', async function () {
-    cardanoWorker.getTransactions = async function () {
-      // Return empty transactions list for the specified block
-      return [];
-    };
-    cardanoWorker.lastExportedBlock = 100;
-    cardanoWorker.lastConfirmedBlock = 200;
-    await cardanoWorker.work();
-
-    assert.strictEqual(cardanoWorker.lastExportedBlock, 200);
-  });
 });
 


### PR DESCRIPTION
When the Cardano node is out of sync it would report past last block. This would cause the Cardano exporter to abandon its progress and resume from beginning (block 0). By looking at the code I couldn't identify under what situation this happens, we already added some guards against this. However I am removing one potential problem line.