### PR TITLE
Adding retry functionality

### DIFF
--- a/blockchains/utxo/lib/constants.js
+++ b/blockchains/utxo/lib/constants.js
@@ -1,21 +1,24 @@
-const MAX_CONCURRENT_REQUESTS = parseInt(process.env.MAX_CONCURRENT_REQUESTS || '10');
-const DEFAULT_TIMEOUT = parseInt(process.env.DEFAULT_TIMEOUT || '10000');
-const CONFIRMATIONS = parseInt(process.env.CONFIRMATIONS || '3');
-const NODE_URL = process.env.NODE_URL || 'http://litecoin.stage.san:30992';
 const RPC_USERNAME = process.env.RPC_USERNAME || 'rpcuser';
 const RPC_PASSWORD = process.env.RPC_PASSWORD || 'rpcpassword';
-const EXPORT_TIMEOUT_MLS = parseInt(process.env.EXPORT_TIMEOUT_MLS || 1000 * 60 * 15); // 15 minutes
-const LOOP_INTERVAL_CURRENT_MODE_SEC = parseInt(process.env.LOOP_INTERVAL_CURRENT_MODE_SEC || '30');
+const NODE_URL = process.env.NODE_URL;
+
 const DOGE = process.env.DOGE || 0;
+const MAX_RETRIES = parseInt(process.env.MAX_RETRIES) || 3;
+const CONFIRMATIONS = parseInt(process.env.CONFIRMATIONS) || 3;
+const DEFAULT_TIMEOUT = parseInt(process.env.DEFAULT_TIMEOUT) || 10000;
+const MAX_CONCURRENT_REQUESTS = parseInt(process.env.MAX_CONCURRENT_REQUESTS) || 10;
+const EXPORT_TIMEOUT_MLS = parseInt(process.env.EXPORT_TIMEOUT_MLS) || 1000 * 60 * 15; // 15 minutes
+const LOOP_INTERVAL_CURRENT_MODE_SEC = parseInt(process.env.LOOP_INTERVAL_CURRENT_MODE_SEC) || 30;
 
 module.exports = {
-  MAX_CONCURRENT_REQUESTS,
-  DEFAULT_TIMEOUT,
-  CONFIRMATIONS,
+  DOGE,
+  NODE_URL,
+  MAX_RETRIES,
   RPC_USERNAME,
   RPC_PASSWORD,
-  NODE_URL,
+  CONFIRMATIONS,
+  DEFAULT_TIMEOUT,
   EXPORT_TIMEOUT_MLS,
-  DOGE,
+  MAX_CONCURRENT_REQUESTS,
   LOOP_INTERVAL_CURRENT_MODE_SEC
 };

--- a/blockchains/utxo/utxo_worker.js
+++ b/blockchains/utxo/utxo_worker.js
@@ -4,15 +4,17 @@ const { parseURL } = require('whatwg-url');
 const { logger } = require('../../lib/logger');
 const BaseWorker = require('../../lib/worker_base');
 const {
+  DOGE,
   NODE_URL,
+  MAX_RETRIES,
   RPC_PASSWORD,
   RPC_USERNAME,
-  DEFAULT_TIMEOUT,
-  DOGE,
   CONFIRMATIONS,
-  LOOP_INTERVAL_CURRENT_MODE_SEC,
-  MAX_CONCURRENT_REQUESTS
+  DEFAULT_TIMEOUT,
+  MAX_CONCURRENT_REQUESTS,
+  LOOP_INTERVAL_CURRENT_MODE_SEC
 } = require('./lib/constants');
+
 const URL = parseURL(NODE_URL);
 
 class UtxoWorker extends BaseWorker {
@@ -31,7 +33,7 @@ class UtxoWorker extends BaseWorker {
   }
 
   async init() {
-    const blockchainInfo = await this.sendRequest('getblockchaininfo', []);
+    const blockchainInfo = await this.sendRequestWithRetry('getblockchaininfo', []);
     this.lastConfirmedBlock = blockchainInfo.blocks - CONFIRMATIONS;
   }
 
@@ -45,14 +47,40 @@ class UtxoWorker extends BaseWorker {
     });
   }
 
+  async sendRequestWithRetry(method, params) {
+    let retries = 0;
+    let retryIntervalMs = 0;
+    while (retries < MAX_RETRIES) {
+      try {
+        const response = await this.sendRequest(method, params).catch(err => Promise.reject(err));
+        if (response.error || response.result === null) {
+          retries++;
+          retryIntervalMs += (2000 * retries);
+          logger.error(`sendRequest with ${method} failed. Reason: ${response.error}. Retrying for ${retries} time`);
+          await new Promise((resolve) => setTimeout(resolve, retryIntervalMs));
+          continue;
+        }
+        return response;
+      } catch(err) {
+        retries++;
+        retryIntervalMs += (2000 * retries);
+        logger.error(
+          `Try block in sendRequest for ${method} failed. Reason: ${err.toString()}. Waiting ${retryIntervalMs} and retrying for ${retries} time`
+          );
+        await new Promise((resolve) => setTimeout(resolve, retryIntervalMs));
+      }
+    }
+    return Promise.reject(`sendRequest for ${method} failed after ${MAX_RETRIES} retries`);
+  }
+
   async decodeTransaction(transaction_bytecode) {
-    return await this.sendRequest('decoderawtransaction', [transaction_bytecode]);
+    return await this.sendRequestWithRetry('decoderawtransaction', [transaction_bytecode]);
   }
 
   async getTransactionData(transaction_hashes) {
     const decodedTransactions = [];
     for (const transaction_hash of transaction_hashes) {
-      const transactionBytecode = await this.sendRequest('getrawtransaction', [transaction_hash]);
+      const transactionBytecode = await this.sendRequestWithRetry('getrawtransaction', [transaction_hash]);
       const decodedTransaction = await this.decodeTransaction(transactionBytecode);
       decodedTransactions.push(decodedTransaction);
     }
@@ -61,22 +89,22 @@ class UtxoWorker extends BaseWorker {
   }
 
   async fetchBlock(block_index) {
-    let blockHash = await this.sendRequest('getblockhash', [block_index]);
+    let blockHash = await this.sendRequestWithRetry('getblockhash', [block_index]);
     if (DOGE) {
-      let blockData = await this.sendRequest('getblock', [blockHash, true]);
+      let blockData = await this.sendRequestWithRetry('getblock', [blockHash, true]);
       let transactionData = await this.getTransactionData(blockData.tx);
       blockData['tx'] = transactionData;
 
       return blockData;
     }
-    return await this.sendRequest('getblock', [blockHash, 2]);
+    return await this.sendRequestWithRetry('getblock', [blockHash, 2]);
   }
 
   async work() {
     if (this.lastConfirmedBlock === this.lastExportedBlock) {
       this.sleepTimeMsec = LOOP_INTERVAL_CURRENT_MODE_SEC * 1000;
 
-      const blockchainInfo = await this.sendRequest('getblockchaininfo', []);
+      const blockchainInfo = await this.sendRequestWithRetry('getblockchaininfo', []);
       const newConfirmedBlock = blockchainInfo.blocks - CONFIRMATIONS;
       if (newConfirmedBlock === this.lastConfirmedBlock) {
         return [];

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "test": "CONTRACT_MAPPING_FILE_PATH=test/erc20/contract_mapping/contract_mapping.json LOG_LEVEL=error CONTRACT_MODE=extract_exact_overwrite mocha --recursive --reporter spec",
-    "lint": "eslint '**/*.js'"
+    "lint": "eslint '**/*.js'",
+    "start": "node index.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Description
* Adding the same retry functionality, that I've added some time ago in the utxo-blocks-exporter repo
* Ordering the constants.js file in a more convenient for the eye way
* Bringing back "npm start", as this is the way I, and also other collegues, test out stuff locally, as it's more convenient. Not to be used in production environments, as explained in this [PR](#139)