### PR TITLE
Fix for 'Maximum call stack size exceeded'

### DIFF
--- a/blockchains/erc20/erc20_worker.js
+++ b/blockchains/erc20/erc20_worker.js
@@ -113,7 +113,10 @@ class ERC20Worker extends BaseWorker {
       if (this.contractsUnmodified.length > 0) {
         const rawEvents = await getPastEvents(this.web3, result.fromBlock, result.toBlock, this.contractsUnmodified,
           timestampsCache);
-        events.push(...rawEvents);
+
+        for (let event of rawEvents) {
+          events.push(event);
+        }
       }
     }
     else {

--- a/blockchains/erc20/erc20_worker.js
+++ b/blockchains/erc20/erc20_worker.js
@@ -114,7 +114,7 @@ class ERC20Worker extends BaseWorker {
         const rawEvents = await getPastEvents(this.web3, result.fromBlock, result.toBlock, this.contractsUnmodified,
           timestampsCache);
 
-        for (let event of rawEvents) {
+        for (const event of rawEvents) {
           events.push(event);
         }
       }


### PR DESCRIPTION
Using the spread operator on a huge array would throw error. Go back to good old iteration.