### PR TITLE
Fix for eth receipts

### DIFF
--- a/blockchains/receipts/lib/helper.js
+++ b/blockchains/receipts/lib/helper.js
@@ -26,6 +26,9 @@ const decodeLog = (log, web3Wrapper) => {
       if (Object.prototype.hasOwnProperty.call(log, key) && log[key] !== undefined) {
         log[key] = web3Wrapper.parseHexToNumber(log[key]);
       }
+      else {
+        log[key] = null;
+      }
     }
   );
 
@@ -50,6 +53,9 @@ const decodeReceipt = (receipt, web3Wrapper) => {
     key => {
       if (Object.prototype.hasOwnProperty.call(clonedReceipt, key) && clonedReceipt[key] !== undefined) {
         clonedReceipt[key] = web3Wrapper.parseHexToNumber(clonedReceipt[key]);
+      }
+      else {
+        clonedReceipt[key] = null;
       }
     }
   );


### PR DESCRIPTION
Naively I thought that we should not output arrays of nulls if a field is missing in a blockchain event. The arrays of nulls look like so:

` "logs.transactionLogIndex": [null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null,   null, null, null, null, null, null, null, null]
`
however removing those breaks the import inside the CH table and potentially some code which depends on the `eth_receipts` table.