### PR TITLE
Increase TCP session inactivity timeout from 5 to 30 seconds

### DIFF
--- a/blockchains/erc20/erc20_worker.js
+++ b/blockchains/erc20/erc20_worker.js
@@ -1,7 +1,7 @@
 'use strict';
 const { Web3 } = require('web3');
-const jayson = require('jayson/promise');
 const { logger } = require('../../lib/logger');
+const { constructRPCClient } = require('../../lib/http_client');
 const { extendEventsWithPrimaryKey } = require('./lib/extend_events_key');
 const { ContractOverwrite, changeContractAddresses, extractChangedContractAddresses } = require('./lib/contract_overwrite');
 const { stableSort, readJsonFile } = require('./lib/util');
@@ -38,11 +38,7 @@ class ERC20Worker extends BaseWorker {
     logger.info(`Applying the following settings: ${JSON.stringify(settings)}`);
     this.web3Wrapper = web3Wrapper || new Web3Wrapper(new Web3(new Web3.providers.HttpProvider(settings.NODE_URL)));
     if (!ethClient) {
-      if (settings.NODE_URL.substring(0, 5) === 'https') {
-        this.ethClient = jayson.client.https(settings.NODE_URL);
-      } else {
-        this.ethClient = jayson.client.http(settings.NODE_URL);
-      }
+      this.ethClient = constructRPCClient(settings.NODE_URL);
       this.contractsOverwriteArray = [];
       this.contractsUnmodified = [];
       this.allOldContracts = [];

--- a/blockchains/erc20/lib/fetch_events.js
+++ b/blockchains/erc20/lib/fetch_events.js
@@ -185,7 +185,7 @@ async function getPastEvents(web3Wrapper, fromBlock, toBlock, contractAddress, t
   const events = await getRawEvents(web3Wrapper, fromBlock, toBlock, contractAddress);
   const startTime = Date.now();
   await timestampsCache.waitResponse();
-  logger.info(`Block timestamps resolved in ${Date.now() - startTime} msecs`);
+  logger.debug(`Block timestamps resolved in ${Date.now() - startTime} msecs`);
   const decodedEvents = decodeEvents(web3Wrapper, events, timestampsCache);
   const result = filterEvents(decodedEvents);
 

--- a/blockchains/erc20/lib/fetch_events.js
+++ b/blockchains/erc20/lib/fetch_events.js
@@ -2,6 +2,7 @@
 
 const { decodeAddress } = require('./util');
 const { addCustomTokenDistribution } = require('./custom_token_distribution');
+const { logger } = require('../../../lib/logger');
 
 
 const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
@@ -182,7 +183,9 @@ const decodeFunctionsMap = {
 
 async function getPastEvents(web3Wrapper, fromBlock, toBlock, contractAddress, timestampsCache) {
   const events = await getRawEvents(web3Wrapper, fromBlock, toBlock, contractAddress);
+  const startTime = Date.now();
   await timestampsCache.waitResponse();
+  logger.info(`Block timestamps resolved in ${Date.now() - startTime} msecs`);
   const decodedEvents = decodeEvents(web3Wrapper, events, timestampsCache);
   const result = filterEvents(decodedEvents);
 

--- a/blockchains/eth/eth_worker.js
+++ b/blockchains/eth/eth_worker.js
@@ -1,4 +1,6 @@
 const { Web3 } = require('web3');
+const http = require('http');
+const https = require('https');
 const jayson = require('jayson/promise');
 const { filterErrors } = require('./lib/filter_errors');
 const { logger } = require('../../lib/logger');
@@ -19,10 +21,28 @@ class ETHWorker extends BaseWorker {
     logger.info(`Connecting to Ethereum node ${settings.NODE_URL}`);
     logger.info(`Applying the following settings: ${JSON.stringify(settings)}`);
     this.web3Wrapper = new Web3Wrapper(new Web3(new Web3.providers.HttpProvider(settings.NODE_URL)));
+
+    const nodeUrl = new URL(settings.NODE_URL);
+
+    const jaysonOptions = {
+      hostname: nodeUrl.hostname,
+      port: nodeUrl.port,
+      path: nodeUrl.pathname
+    };
+
+    const agentOptions = {
+      keepAlive: true,       // Enable keep-alive
+      keepAliveMsecs: 30000 // Keep alive for 30 seconds
+    };
+
     if (settings.NODE_URL.substring(0, 5) === 'https') {
-      this.ethClient = jayson.client.https(settings.NODE_URL);
+      const agent = new https.Agent(agentOptions);
+      jaysonOptions.agent = agent;
+      this.ethClient = jayson.client.https(jaysonOptions);
     } else {
-      this.ethClient = jayson.client.http(settings.NODE_URL);
+      const agent = new http.Agent(agentOptions);
+      jaysonOptions.agent = agent;
+      this.ethClient = jayson.client.http(jaysonOptions);
     }
     this.feesDecoder = new FeesDecoder(this.web3Wrapper);
     this.withdrawalsDecoder = new WithdrawalsDecoder(this.web3Wrapper);

--- a/blockchains/matic/matic_worker.js
+++ b/blockchains/matic/matic_worker.js
@@ -1,6 +1,6 @@
 const { Web3 } = require('web3');
-const jayson = require('jayson/promise');
 const { logger } = require('../../lib/logger');
+const { constructRPCClient } = require('../../lib/http_client');
 const BaseWorker = require('../../lib/worker_base');
 const Web3Wrapper = require('../eth/lib/web3_wrapper');
 const { extendEventsWithPrimaryKey } = require('../erc20/lib/extend_events_key');
@@ -14,11 +14,7 @@ class MaticWorker extends BaseWorker {
 
     logger.info(`Connecting to Polygon node ${settings.NODE_URL}`);
     this.web3Wrapper = new Web3Wrapper(new Web3(new Web3.providers.HttpProvider(settings.NODE_URL)));
-    if (settings.NODE_URL.substring(0, 5) === 'https') {
-      this.ethClient = jayson.client.https(settings.NODE_URL);
-    } else {
-      this.ethClient = jayson.client.http(settings.NODE_URL);
-    }
+    this.ethClient = constructRPCClient(settings.NODE_URL);
   }
 
   async work() {

--- a/blockchains/receipts/receipts_worker.js
+++ b/blockchains/receipts/receipts_worker.js
@@ -1,9 +1,8 @@
 'use strict';
 const { Web3 } = require('web3');
-const jayson = require('jayson/promise');
-
 const helper = require('./lib/helper');
 const { logger } = require('../../lib/logger');
+const { constructRPCClient } = require('../../lib/http_client');
 const BaseWorker = require('../../lib/worker_base');
 const Web3Wrapper = require('../eth/lib/web3_wrapper');
 
@@ -13,7 +12,7 @@ class ReceiptsWorker extends BaseWorker {
     super(settings);
 
     logger.info(`Connecting to node ${settings.NODE_URL}`);
-    this.client = jayson.client.https(settings.NODE_URL);
+    this.client = constructRPCClient(settings.NODE_URL);
     this.web3Wrapper = new Web3Wrapper(new Web3(new Web3.providers.HttpProvider(settings.NODE_URL)));
   }
 

--- a/blockchains/utxo/utxo_worker.js
+++ b/blockchains/utxo/utxo_worker.js
@@ -1,7 +1,6 @@
 'use strict';
-const jayson = require('jayson/promise');
-const { parseURL } = require('whatwg-url');
 const { logger } = require('../../lib/logger');
+const { constructRPCClient } = require('../../lib/http_client');
 const BaseWorker = require('../../lib/worker_base');
 
 
@@ -18,12 +17,8 @@ class UtxoWorker extends BaseWorker {
     this.MAX_CONCURRENT_REQUESTS = settings.MAX_CONCURRENT_REQUESTS;
     this.LOOP_INTERVAL_CURRENT_MODE_SEC = settings.LOOP_INTERVAL_CURRENT_MODE_SEC;
 
-    const url = parseURL(this.NODE_URL);
-
     logger.info(`Connecting to the node ${this.NODE_URL}`);
-    this.client = jayson.Client.https({
-      host: url.host,
-      port: url.port,
+    this.client = constructRPCClient(this.NODE_URL, {
       method: 'POST',
       auth: this.RPC_USERNAME + ':' + this.RPC_PASSWORD,
       timeout: this.DEFAULT_TIMEOUT,

--- a/lib/http_client.js
+++ b/lib/http_client.js
@@ -1,0 +1,38 @@
+const http = require('http');
+const https = require('https');
+const jayson = require('jayson/promise');
+
+// The TCP session constructed by Node HTTP module would get closed after 5 seconds of inactivity by default.
+// Extend this timeout to 30 to reduce the number of sessions constructed.
+const TCP_SESSION_KEEP_ALIVE_MSEC = 30000;
+
+function constructRPCClient(nodeURL, extraOptions = {}) {
+    const nodeUrl = new URL(nodeURL);
+
+    const mergedOptions = {
+        hostname: nodeUrl.hostname,
+        port: nodeUrl.port,
+        path: nodeUrl.pathname,
+        ...extraOptions
+    };
+
+    const agentOptions = {
+        keepAlive: true, // Enable keep-alive
+        keepAliveMsecs: TCP_SESSION_KEEP_ALIVE_MSEC // Keep alive for 30 seconds
+    };
+
+    if (nodeURL.substring(0, 5) === 'https') {
+        const agent = new https.Agent(agentOptions);
+        mergedOptions.agent = agent;
+        return jayson.client.https(mergedOptions);
+    } else {
+        const agent = new http.Agent(agentOptions);
+        mergedOptions.agent = agent;
+        return jayson.client.http(mergedOptions);
+    }
+}
+
+
+module.exports = {
+    constructRPCClient: constructRPCClient
+};

--- a/lib/http_client.js
+++ b/lib/http_client.js
@@ -34,5 +34,5 @@ function constructRPCClient(nodeURL, extraOptions = {}) {
 
 
 module.exports = {
-    constructRPCClient: constructRPCClient
+    constructRPCClient
 };

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "prom-client": "^13.1.0",
     "segfault-handler": "^1.3.0",
     "web3": "^4.2.2",
-    "whatwg-url": "^11.0.0",
     "xrpl": "^2.6.0",
     "p-retry": "^6.1.0"
   },


### PR DESCRIPTION
It turned out that the TCP session constructed by Node HTTP module would have an inactivity timeout of 5 seconds by default. To prove this observation I constructed a simple client-server application:

The server:

```js
const http = require('http');

const server = http.createServer((req, res) => {
  if (req.method === 'POST') {
    let body = '';

    req.on('data', chunk => {
      body += chunk.toString(); // Convert binary chunk to string
    });

    req.on('end', () => {
      try {
        const jsonRpcRequest = JSON.parse(body);

        if (jsonRpcRequest.method === 'multiply' && Array.isArray(jsonRpcRequest.params)) {
          // Perform the multiplication
          const result = jsonRpcRequest.params[0] * jsonRpcRequest.params[1];
          const response = {
            jsonrpc: '2.0',
            id: jsonRpcRequest.id,
            result: result
          };
          res.writeHead(200, { 'Content-Type': 'application/json' });
          res.end(JSON.stringify(response));
        } else {
          // Invalid method or params
          res.writeHead(400);
          res.end('Invalid JSON-RPC method or params');
        }
      } catch (error) {
        // Error parsing JSON or handling the request
        res.writeHead(500);
        res.end('Server error: ' + error.message);
      }
    });
  } else {
    // Not a POST request
    res.writeHead(405); // Method Not Allowed
    res.end();
  }
});

server.listen(3000, () => {
  console.log('Server listening on http://localhost:3000');
});
```


The client:

```js
const http = require('http');

// A function to send JSON-RPC requests
function sendJsonRpcRequest(method, params, id, callback) {
  const data = JSON.stringify({
    jsonrpc: '2.0',
    method: method,
    params: params,
    id: id
  });

  const options = {
    hostname: 'localhost',
    port: 3000,
    path: '/',
    method: 'POST',
    headers: {
      'Content-Type': 'application/json',
      'Content-Length': Buffer.byteLength(data)
    }
  };

  const req = http.request(options, res => {
    res.setEncoding('utf8');
    let responseBody = '';

    res.on('data', chunk => {
      responseBody += chunk;
    });

    res.on('end', () => {
      try {
        const response = JSON.parse(responseBody);
        callback(null, response);
      } catch (error) {
        callback(error);
      }
    });
  });

  req.on('error', callback);
  req.write(data);
  req.end();
}

// A client request to the multiply method
sendJsonRpcRequest('multiply', [5, 5], 1, (err, response) => {
  if (err) {
    console.error('Error:', err);
    return;
  }

  console.log('Result:', response.result); // 25
});

setTimeout(() => {
  console.log('Time is up. Exit.');
}, 60000);

```

The network communication of this application is this:

![image](https://github.com/santiment/san-chain-exporter/assets/3602846/61e87dbd-dce3-4e98-a607-11ad592fc716)

As you can see there are 5 keep alive packets sent with 1 second interval between them, and then the connection is closed. This behavior affects the Jayson library we use, which is a thin wrapper of the Node HTTP module, providing some RPC functionality.
