### PR TITLE
Await for abortTransaction response

### DIFF
--- a/lib/kafka_storage.js
+++ b/lib/kafka_storage.js
@@ -360,7 +360,7 @@ class Exporter {
       await this.commitTransaction();
     } catch (exception) {
       logger.error('Error storing data to Kafka:' + exception);
-      this.abortTransaction();
+      await this.abortTransaction();
       throw exception;
     }
   }


### PR DESCRIPTION
We suspect not awaiting for the `abortTransaction` response may be causing some issues around stuck transactions. 