### PR TITLE
When no transactions are fetched move interval by one block

### DIFF
--- a/src/blockchains/cardano/cardano_worker.js
+++ b/src/blockchains/cardano/cardano_worker.js
@@ -202,6 +202,8 @@ class CardanoWorker extends BaseWorker {
     else {
       transactions = await this.getTransactions(fromBlock, this.lastConfirmedBlock);
       if (transactions.length === 0) {
+        // Move the export interval by one block. This would prevent entering a loop asking for same interval.
+        this.lastExportedBlock = fromBlock;
         return [];
       }
     }


### PR DESCRIPTION
When the Cardano exporter returns no transactions for an interval, move the progress by one block. We ask for interval X to Y, so usually we would have marked the interval as reached Y. However I am not sure that the graphql really gives us the whole interval if it is a huge one, so maybe it is safer to must move it with 1, this would still prevent deadlocks.