### PR TITLE
highlighting rpc issue

### DIFF
--- a/src/integration_test/src/binance-native-token.spec.js
+++ b/src/integration_test/src/binance-native-token.spec.js
@@ -1,3 +1,10 @@
+const {logger} = require('../../lib/logger');
+
+const { Web3 } = require('web3');
+
+const Web3Wrapper = require('../../blockchains/eth/lib/web3_wrapper');
+const { constructRPCClient } = require('../../lib/http_client');
+
 const assert = require('assert');
 const TaskManager = require('../../lib/task_manager');
 const worker = require('../../blockchains/eth/eth_worker');
@@ -5,6 +12,27 @@ const { nextIntervalCalculator } = require('../../blockchains/eth/lib/next_inter
 
 
 describe('BSC worker test', function () {
+
+  it("trace_filter is not stable", async function() {
+    let web3Wrapper = new Web3Wrapper(new Web3(new Web3.providers.HttpProvider('https://binance.santiment.net')));
+    let fromBlock = 20000000
+    let toBlock = fromBlock + 50
+    let arr = [...Array(6).keys()] // range 0,1,2...
+    let blocks_fetch = arr.map(iter => constructRPCClient('https://binance.santiment.net').request('trace_filter', [{
+      fromBlock: web3Wrapper.parseNumberToHex(fromBlock + iter * 100),
+      toBlock: web3Wrapper.parseNumberToHex(toBlock + iter * 100)
+    }]).then((data) => {
+      let blocks = new Set(data.result.map((element) => element.blockNumber))
+      let blocksArr = [...blocks.keys()]
+      logger.info(`${iter}, ${blocks.size} ${Math.min.apply(Math, blocksArr)} ${Math.max.apply(Math, blocksArr)}`)
+      return blocks.size
+    })
+    )
+    let result = await Promise.all(blocks_fetch)
+    logger.info(result)    
+    result.forEach(element => assert.equal(element, 51))
+  }, 90000)
+
   it('BSC worker should extract blocks from 20000000 to 20000249 including', async function () {
     this.timeout(120000);
     const expectedData = require('../testdata/binance_native_token_block_20000000_to_20000999.json');


### PR DESCRIPTION
Basically `trace_filter` doesn't return N records requested in request. It returns up to N according to this test.

In this test I count amount of blocks we have in response. You can see that sometimes node returns less. In my experiments node returns blocks sequentially but amount of blocks may vary. That's why I believe we used to work well without async block querying. If you do 
```
val blocks = request(latestBlock)
this.latestBlock = this.latestBlock + blocks.size
```
then this error doesn't bite you.


For some records it returns interesting errs like this but if you query the node multiple times it returns expected amount of data (it works fast if data was cached). 
![image](https://github.com/santiment/san-chain-exporter/assets/739463/cbdcfd78-52df-4975-9fa3-910284004cf3)
