### PR TITLE
ETH blocks exporter also exposes number of transactions in a block

### DIFF
--- a/src/blockchains/eth/eth_types.ts
+++ b/src/blockchains/eth/eth_types.ts
@@ -41,7 +41,8 @@ export type ETHBlock = {
   minGasPrice?: string
   // Withdrawals should be set for ETH post-Shenghai upgrade
   withdrawals?: BeaconChainWithdrawal[],
-  transactions: ETHTransaction[]
+  // Transactions can be expanded or just hashes
+  transactions: ETHTransaction[] | string[]
 }
 
 export type BeaconChainWithdrawal = {

--- a/src/blockchains/eth/eth_worker.ts
+++ b/src/blockchains/eth/eth_worker.ts
@@ -35,7 +35,7 @@ export class ETHWorker extends BaseWorker {
   async fetchData(fromBlock: number, toBlock: number): Promise<[Trace[], Map<number, ETHBlock>, ETHReceiptsMap]> {
     return await Promise.all([
       fetchEthInternalTrx(this.ethClient, this.web3Wrapper, fromBlock, toBlock),
-      fetchBlocks(this.ethClient, this.web3Wrapper, fromBlock, toBlock),
+      fetchBlocks(this.ethClient, this.web3Wrapper, fromBlock, toBlock, true),
       fetchReceipts(this.ethClient, this.web3Wrapper,
         this.settings.RECEIPTS_API_METHOD, fromBlock, toBlock),
     ]);

--- a/src/blockchains/eth/lib/fees_decoder.ts
+++ b/src/blockchains/eth/lib/fees_decoder.ts
@@ -1,6 +1,13 @@
+import assert from 'assert'
 import { Web3Interface, safeCastToNumber } from './web3_wrapper';
 import { ETHBlock, ETHTransaction, ETHTransfer, ETHReceiptsMap } from '../eth_types';
 import { BURN_ADDRESS, LONDON_FORK_BLOCK } from './constants';
+
+
+function isETHTransaction(transaction: ETHTransaction | string): transaction is ETHTransaction {
+  return typeof transaction === 'object' && 'hash' in transaction && 'from' in transaction;
+}
+
 export class FeesDecoder {
   private web3Wrapper: Web3Interface;
 
@@ -89,7 +96,9 @@ export class FeesDecoder {
 
   getFeesFromTransactionsInBlock(block: ETHBlock, blockNumber: number, receipts: ETHReceiptsMap, isETH: boolean): ETHTransfer[] {
     const result: ETHTransfer[] = [];
-    block.transactions.forEach((transaction: ETHTransaction) => {
+    block.transactions.forEach((transaction: ETHTransaction | string) => {
+      assert(isETHTransaction(transaction), "To get fees, ETH transaction should be expanded and not just the hash.");
+
       const feeTransfers: ETHTransfer[] =
         isETH && blockNumber >= LONDON_FORK_BLOCK ?
           this.getPostLondonForkFees(transaction, block, receipts) :

--- a/src/blockchains/eth/lib/fetch_data.ts
+++ b/src/blockchains/eth/lib/fetch_data.ts
@@ -24,13 +24,13 @@ export function fetchEthInternalTrx(ethClient: HTTPClientInterface,
 }
 
 export async function fetchBlocks(ethClient: HTTPClientInterface,
-  web3Wrapper: Web3Interface, fromBlock: number, toBlock: number): Promise<Map<number, ETHBlock>> {
+  web3Wrapper: Web3Interface, fromBlock: number, toBlock: number, getTransactionDetails: boolean): Promise<Map<number, ETHBlock>> {
   const blockRequests: any[] = [];
   for (let i = fromBlock; i <= toBlock; i++) {
     blockRequests.push(
       ethClient.generateRequest(
         'eth_getBlockByNumber',
-        [web3Wrapper.parseNumberToHex(i), true]
+        [web3Wrapper.parseNumberToHex(i), getTransactionDetails]
       )
     );
   }

--- a/src/blockchains/eth_blocks/eth_blocks_worker.ts
+++ b/src/blockchains/eth_blocks/eth_blocks_worker.ts
@@ -32,7 +32,8 @@ export class ETHBlocksWorker extends BaseWorker {
       size: this.web3Wrapper.parseHexToNumber(block.size),
       gasLimit: this.web3Wrapper.parseHexToNumberString(block.gasLimit),
       gasUsed: this.web3Wrapper.parseHexToNumberString(block.gasUsed),
-      number: this.web3Wrapper.parseHexToNumber(block.number)
+      number: this.web3Wrapper.parseHexToNumber(block.number),
+      transactionCount: block.transactions.length
     }
 
     if (block.minGasPrice !== undefined) {
@@ -53,7 +54,7 @@ export class ETHBlocksWorker extends BaseWorker {
 
     const { fromBlock, toBlock } = nextIntervalCalculator(this);
     logger.info(`Fetching blocks events for interval ${fromBlock}:${toBlock}`);
-    const blocks = await fetchBlocks(this.ethClient, this.web3Wrapper, fromBlock, toBlock);
+    const blocks = await fetchBlocks(this.ethClient, this.web3Wrapper, fromBlock, toBlock, false);
     const events = Array.from(blocks).map(([key, block]) => this.decodeBlock(block));
 
     this.lastExportedBlock = toBlock;


### PR DESCRIPTION
A small extension to the ETH blocks exporter functionality. As part of the statistics that we export for each block - export the number of transactions, output data would look like this:

```json
{
  "hash": "0x9ee35049c3e9f8a52bce414d85ae4b7187612c368ab95347c076221c85b13596",
  "miner": "0x4838b106fce9647bdf1e7877bf73ce8b0bad5f97",
  "difficulty": "0",
  "totalDifficulty": "58750003716598352816469",
  "timestamp": "1717675403",
  "size": 67080,
  "gasLimit": "30000000",
  "gasUsed": "14407428",
  "number": 20032662,
  "transactionCount": 132 // This is new
}
```

This new data would allow us to deprecate the [ETH transactions](https://github.com/santiment/eth-transactions-exporter) exporter. The data it exports has a very limited usage in our pipeline, we use it just to count the number of transactions and it's an overkill to store all the transactions just for this purpose.
