### PR TITLE
Break 'Exporter' into KafkaStorage and ZookeeperState classes

### DIFF
--- a/src/blockchains/erc20/erc20_worker.ts
+++ b/src/blockchains/erc20/erc20_worker.ts
@@ -1,6 +1,6 @@
 'use strict';
 import { logger } from '../../lib/logger';
-import { Exporter } from '../../lib/kafka_storage';
+import { KafkaStorage } from '../../lib/kafka_storage';
 import { constructRPCClient } from '../../lib/http_client';
 import { extendEventsWithPrimaryKey } from './lib/extend_events_key';
 import { ContractOverwrite, changeContractAddresses, extractChangedContractAddresses } from './lib/contract_overwrite';
@@ -59,7 +59,7 @@ export class ERC20Worker extends BaseWorker {
     this.allOldContracts = [];
   }
 
-  async init(exporter?: Exporter) {
+  async init(exporter?: KafkaStorage) {
     this.lastConfirmedBlock = await this.web3Wrapper.getBlockNumber() - this.settings.CONFIRMATIONS;
 
     if (this.settings.EXPORT_BLOCKS_LIST) {

--- a/src/blockchains/utxo/utxo_worker.ts
+++ b/src/blockchains/utxo/utxo_worker.ts
@@ -2,7 +2,7 @@
 import { logger } from '../../lib/logger';
 import { constructRPCClient } from '../../lib/http_client';
 import { BaseWorker } from '../../lib/worker_base';
-import { Exporter } from '../../lib/kafka_storage';
+import { KafkaStorage } from '../../lib/kafka_storage';
 import { HTTPClientInterface } from '../../types';
 
 
@@ -33,7 +33,7 @@ export class UTXOWorker extends BaseWorker {
     this.client = constructRPCClient(this.NODE_URL, this.RPC_USERNAME, this.RPC_PASSWORD, this.DEFAULT_TIMEOUT);
   }
 
-  async init(exporter: Exporter) {
+  async init(exporter: KafkaStorage) {
     const blockchainInfo = await this.sendRequestWithRetry('getblockchaininfo', []);
     this.lastConfirmedBlock = blockchainInfo.blocks - this.CONFIRMATIONS;
     await exporter.initPartitioner((event: any) => event['height']);

--- a/src/lib/worker_base.ts
+++ b/src/lib/worker_base.ts
@@ -1,6 +1,6 @@
 'use strict';
 import { logger } from './logger';
-import { Exporter } from './kafka_storage';
+import { KafkaStorage } from './kafka_storage';
 import { ExporterPosition } from '../types'
 
 export class BaseWorker {
@@ -34,7 +34,7 @@ export class BaseWorker {
     throw new Error('"work" method need to be overriden');
   }
   // To be implemented on inheritance.
-  async init(_exporter: Exporter) {
+  async init(_exporter: KafkaStorage) {
     throw new Error('"init" method need to be overriden');
   }
 

--- a/src/lib/zookeeper_state.ts
+++ b/src/lib/zookeeper_state.ts
@@ -1,0 +1,110 @@
+import ZookeeperClientAsync from './zookeeper_client_async';
+import { logger } from './logger';
+
+
+const ZOOKEEPER_URL: string = process.env.ZOOKEEPER_URL || 'localhost:2181';
+const ZOOKEEPER_RETRIES: number = parseInt(process.env.ZOOKEEPER_RETRIES || '0');
+const ZOOKEEPER_SPIN_DELAY: number = parseInt(process.env.ZOOKEEPER_SPIN_DELAY || '1000');
+const ZOOKEEPER_SESSION_TIMEOUT: number = parseInt(process.env.ZOOKEEPER_SESSION_TIMEOUT || '30000');
+
+const FORMAT_HEADER: string = 'format=json;';
+
+
+export class ZookeeperState {
+  private readonly exporter_name: string;
+  private readonly topicName: string;
+  private readonly zookeeperClient: ZookeeperClientAsync;
+
+
+  constructor(exporter_name: string, topicName: string) {
+    this.exporter_name = exporter_name;
+
+    this.topicName = topicName;
+
+    this.zookeeperClient = new ZookeeperClientAsync(ZOOKEEPER_URL,
+      {
+        sessionTimeout: ZOOKEEPER_SESSION_TIMEOUT,
+        spinDelay: ZOOKEEPER_SPIN_DELAY,
+        retries: ZOOKEEPER_RETRIES
+      }
+    );
+  }
+
+  get zookeeperPositionNode() {
+    // Generally it may be an arbitrary position object, not necessarily block number. We keep this name for backward compatibility
+    return `/${this.exporter_name}/${this.topicName}/block-number`;
+  }
+
+  get zookeeperTimestampNode() {
+    return `/${this.exporter_name}/${this.topicName}/timestamp`;
+  }
+
+  /**
+   * @returns {Promise} Promise, resolved on connection completed.
+   */
+  async connect(): Promise<void> {
+    logger.info(`Connecting to zookeeper host ${ZOOKEEPER_URL}`);
+
+    try {
+      await this.zookeeperClient.connectAsync();
+    }
+    catch (ex) {
+      console.error('Error connecting to Zookeeper: ', ex);
+      throw ex;
+    }
+  }
+
+  /**
+   * Disconnect from Zookeeper.
+  */
+  async disconnect() {
+    logger.info(`Disconnecting from zookeeper host ${ZOOKEEPER_URL}`);
+    await this.zookeeperClient.closeAsync();
+  }
+
+  async getLastPosition() {
+    if (await this.zookeeperClient.existsAsync(this.zookeeperPositionNode)) {
+      const previousPosition = await this.zookeeperClient.getDataAsync(
+        this.zookeeperPositionNode
+      );
+
+      try {
+        if (Buffer.isBuffer(previousPosition && previousPosition.data)) {
+          const value = previousPosition.data.toString('utf8');
+
+          if (value.startsWith(FORMAT_HEADER)) {
+            return JSON.parse(value.replace(FORMAT_HEADER, ''));
+          } else {
+            return previousPosition.data;
+          }
+        }
+      } catch (err) {
+        logger.error(err);
+      }
+    }
+
+    return null;
+  }
+
+  async savePosition(position: object) {
+    if (typeof position !== 'undefined') {
+      const newNodeValue = Buffer.from(
+        FORMAT_HEADER + JSON.stringify(position),
+        'utf-8'
+      );
+
+      if (await this.zookeeperClient.existsAsync(this.zookeeperPositionNode)) {
+        return this.zookeeperClient.setDataAsync(
+          this.zookeeperPositionNode,
+          newNodeValue
+        );
+      } else {
+        return this.zookeeperClient.mkdirpAsync(
+          this.zookeeperPositionNode,
+          newNodeValue
+        );
+      }
+    }
+  }
+}
+

--- a/src/test/index.test.ts
+++ b/src/test/index.test.ts
@@ -8,7 +8,8 @@ import { Main } from '../main';
 const { Main: MainRewired } = rewire('../main');
 const { main } = rewire('../index');
 import { BaseWorker } from '../lib/worker_base';
-import { Exporter } from '../lib/kafka_storage';
+import { KafkaStorage } from '../lib/kafka_storage';
+import { ZookeeperState } from '../lib/zookeeper_state';
 import { ETHWorker } from '../blockchains/eth/eth_worker';
 import * as ethConstants from '../blockchains/eth/lib/constants';
 import zkClientAsync from '../lib/zookeeper_client_async';
@@ -21,8 +22,14 @@ describe('Main tests', () => {
     START_PRIMARY_KEY: -1
   };
 
+  let sandbox: any = null;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+  });
+
   afterEach(() => {
-    sinon.restore();
+    sandbox.restore();
   });
 
   it('initExporter returns error when Exporter connect() fails', async () => {
@@ -31,6 +38,10 @@ describe('Main tests', () => {
       .rejects(new Error('Exporter connection failed'));
 
     const mainInstance = new Main();
+
+    sandbox.stub(KafkaStorage.prototype, 'connect').resolves();
+    sandbox.stub(KafkaStorage.prototype, 'initTransactions').resolves();
+
     try {
       await mainInstance.init(blockchain);
     } catch (err) {
@@ -44,13 +55,8 @@ describe('Main tests', () => {
   });
 
   it('initExporter returns error when Exporter initTransactions() fails', async () => {
-    sinon
-      .stub(Exporter.prototype, 'connect')
-      .resolves();
-
-    sinon
-      .stub(Exporter.prototype, 'initTransactions')
-      .rejects(new Error('Exporter initTransactions failed'));
+    sandbox.stub(KafkaStorage.prototype, 'connect').resolves();
+    sandbox.stub(KafkaStorage.prototype, 'initTransactions').rejects(new Error('Exporter initTransactions failed'));
 
     const mainInstance = new Main();
     try {
@@ -66,11 +72,11 @@ describe('Main tests', () => {
   });
 
   it('handleInitPosition changes the lastProcessedPosition accordingly 1', async () => {
-    const exporterStub = sinon.createStubInstance(Exporter);
-    exporterStub.getLastPosition.returns(JSON.parse('{"blockNumber":123456,"primaryKey":0}'));
+    const zookeeperStub = sandbox.createStubInstance(ZookeeperState);
+    zookeeperStub.getLastPosition.returns(JSON.parse('{"blockNumber":123456,"primaryKey":0}'));
 
     const mainInstance = new MainRewired();
-    mainInstance.exporter = exporterStub;
+    mainInstance.zookeeperState = zookeeperStub;
     mainInstance.worker = new BaseWorker(constants);
 
     sinon.spy(mainInstance, 'handleInitPosition');
@@ -82,11 +88,11 @@ describe('Main tests', () => {
   });
 
   it('handleInitPosition changes the lastProcessedPosition accordingly 2', async () => {
-    const exporterStub = sinon.createStubInstance(Exporter);
-    exporterStub.getLastPosition.returns(null);
+    const zookeeperStub = sandbox.createStubInstance(ZookeeperState);
+    zookeeperStub.getLastPosition.returns(null);
 
     const mainInstance = new MainRewired();
-    mainInstance.exporter = exporterStub;
+    mainInstance.zookeeperState = zookeeperStub;
     mainInstance.worker = new BaseWorker(constants);
 
     sinon.spy(mainInstance, 'handleInitPosition');
@@ -98,11 +104,11 @@ describe('Main tests', () => {
   });
 
   it('handleInitPosition throws error when exporter.getLastPosition() fails', async () => {
-    const exporterStub = sinon.createStubInstance(Exporter);
-    exporterStub.getLastPosition.throws(new Error('Exporter getLastPosition failed'));
+    const zookeeperStub = sandbox.createStubInstance(ZookeeperState);
+    zookeeperStub.getLastPosition.throws(new Error('Exporter getLastPosition failed'));
 
     const mainInstance = new Main();
-    sinon.stub(mainInstance, 'exporter').value(exporterStub);
+    sinon.stub(mainInstance, 'zookeeperState').value(zookeeperStub);
     sinon.stub(mainInstance, 'worker').value(new BaseWorker(constants));
 
     try {
@@ -119,12 +125,12 @@ describe('Main tests', () => {
   });
 
   it('handleInitPosition throws error when exporter.savePosition() fails', async () => {
-    const exporterStub = sinon.createStubInstance(Exporter);
-    exporterStub.getLastPosition.returns(null);
-    exporterStub.savePosition.throws(new Error('Exporter savePosition failed'));
+    const zookeeperStub = sandbox.createStubInstance(ZookeeperState);
+    zookeeperStub.getLastPosition.returns(null);
+    zookeeperStub.savePosition.throws(new Error('Exporter savePosition failed'));
 
     const mainInstance = new Main();
-    sinon.stub(mainInstance, 'exporter').value(exporterStub);
+    sinon.stub(mainInstance, 'zookeeperState').value(zookeeperStub);
     sinon.stub(mainInstance, 'worker').value(new BaseWorker(constants));
 
     try {
@@ -142,7 +148,7 @@ describe('Main tests', () => {
 
   it('initWorker throws error when worker is already present', async () => {
     const mainInstance = new Main();
-    sinon.stub(mainInstance, 'worker').value(new BaseWorker(constants));
+    sandbox.stub(mainInstance, 'worker').value(new BaseWorker(constants));
     try {
       await mainInstance.initWorker('eth', {});
       assert.fail('initWorker should have thrown an error');
@@ -158,9 +164,8 @@ describe('Main tests', () => {
 
   it('initWorker throws an error when worker.init() fails', async () => {
     const mainInstance = new Main();
-    sinon.stub(mainInstance, 'exporter').value(new Exporter('test-exporter', true, 'topic-not-used'));
 
-    sinon.stub(ETHWorker.prototype, 'init').rejects(new Error('Worker init failed'));
+    sandbox.stub(ETHWorker.prototype, 'init').rejects(new Error('Worker init failed'));
 
     try {
       await mainInstance.initWorker('eth', ethConstants);
@@ -177,10 +182,9 @@ describe('Main tests', () => {
 
   it('initWorker throws an error when handleInitPosition() fails', async () => {
     const mainInstance = new Main();
-    sinon.stub(mainInstance, 'exporter').value(new Exporter('test-exporter', true, 'topic-not-used'));
-    sinon.stub(ETHWorker.prototype, 'init').resolves();
+    sandbox.stub(ETHWorker.prototype, 'init').resolves();
 
-    sinon.stub(mainInstance, 'handleInitPosition').throws(new Error('Error when initializing position'));
+    sandbox.stub(mainInstance, 'handleInitPosition').throws(new Error('Error when initializing position'));
 
     try {
       await mainInstance.initWorker('eth', ethConstants);
@@ -197,18 +201,17 @@ describe('Main tests', () => {
 
   it('initWorker success', async () => {
     const mainInstance = new MainRewired();
-    mainInstance.exporter = new Exporter('test-exporter', true, 'topic-not-used');
-    sinon.stub(ETHWorker.prototype, 'init').resolves();
-    sinon.stub(mainInstance, 'handleInitPosition').resolves();
+    sandbox.stub(ETHWorker.prototype, 'init').resolves();
+    sandbox.stub(mainInstance, 'handleInitPosition').resolves();
 
     await mainInstance.initWorker('eth', ethConstants);
     assert(mainInstance.handleInitPosition.calledOnce);
   });
 
-  it('workLoop throws error when worker can\'t be initialised', async () => {
-    sinon.stub(BaseWorker.prototype, 'work').rejects(new Error('Error in worker "work" method'));
+  it('workLoop throws error when worker can not be initialised', async () => {
+    sandbox.stub(BaseWorker.prototype, 'work').rejects(new Error('Error in worker "work" method'));
     const mainInstance = new Main();
-    sinon.stub(mainInstance, 'worker').value(new BaseWorker(constants));
+    sandbox.stub(mainInstance, 'worker').value(new BaseWorker(constants));
     try {
       await mainInstance.workLoop();
       assert.fail('workLoop should have thrown an error');
@@ -223,13 +226,13 @@ describe('Main tests', () => {
   });
 
   it('workLoop throws error when storeEvents() fails', async () => {
-    sinon.stub(BaseWorker.prototype, 'work').resolves([1, 2, 3]);
-    sinon.stub(Main.prototype, 'updateMetrics').returns(null);
-    sinon.stub(Exporter.prototype, 'storeEvents').rejects(new Error('storeEvents failed'));
+    sandbox.stub(BaseWorker.prototype, 'work').resolves([1, 2, 3]);
+    sandbox.stub(Main.prototype, 'updateMetrics').returns(null);
+    sandbox.stub(KafkaStorage.prototype, 'storeEvents').rejects(new Error('storeEvents failed'));
 
     const mainInstance = new Main();
-    sinon.stub(mainInstance, 'worker').value(new BaseWorker(constants));
-    sinon.stub(mainInstance, 'exporter').value(new Exporter('test-exporter', true, 'topic-not-used'));
+    sandbox.stub(mainInstance, 'worker').value(new BaseWorker(constants));
+    sandbox.stub(mainInstance, 'kafkaStorage').value(new KafkaStorage('test-exporter', true, 'topic-not-used'));
     try {
       await mainInstance.workLoop();
       assert.fail('workLoop should have thrown an error');
@@ -244,14 +247,15 @@ describe('Main tests', () => {
   });
 
   it('workLoop throws error when savePosition() fails', async () => {
-    sinon.stub(BaseWorker.prototype, 'work').resolves([1, 2, 3]);
-    sinon.stub(Main.prototype, 'updateMetrics').returns(null);
-    sinon.stub(Exporter.prototype, 'storeEvents').resolves();
-    sinon.stub(Exporter.prototype, 'savePosition').rejects(new Error('savePosition failed'));
+    sandbox.stub(BaseWorker.prototype, 'work').resolves([1, 2, 3]);
+    sandbox.stub(Main.prototype, 'updateMetrics').returns(null);
+    sandbox.stub(KafkaStorage.prototype, 'storeEvents').resolves();
+    sandbox.stub(ZookeeperState.prototype, 'savePosition').rejects(new Error('savePosition failed'));
 
     const mainInstance = new Main();
-    sinon.stub(mainInstance, 'worker').value(new BaseWorker(constants));
-    sinon.stub(mainInstance, 'exporter').value(new Exporter('test-exporter', true, 'topic-not-used'));
+    sandbox.stub(mainInstance, 'worker').value(new BaseWorker(constants));
+    sandbox.stub(mainInstance, 'kafkaStorage').value(new KafkaStorage('test-exporter', true, 'topic-not-used'));
+    sandbox.stub(mainInstance, 'zookeeperState').value(new ZookeeperState('test-exporter', 'topic-not-used'));
 
     try {
       await mainInstance.workLoop();
@@ -269,12 +273,18 @@ describe('Main tests', () => {
 
 
 describe('main function', () => {
+  let sandbox: any = null;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+  });
+
   afterEach(() => {
-    sinon.restore();
+    sandbox.restore();
   });
 
   it('main function throws error when initialization fails', async () => {
-    sinon.stub(Main.prototype, 'init').rejects(new Error('Main init failed'));
+    sandbox.stub(Main.prototype, 'init').rejects(new Error('Main init failed'));
 
     try {
       await main();
@@ -290,8 +300,8 @@ describe('main function', () => {
   });
 
   it('main function throws error when workLoop fails', async () => {
-    sinon.stub(Main.prototype, 'init').resolves();
-    sinon.stub(Main.prototype, 'workLoop').rejects(new Error('Main workLoop failed'));
+    sandbox.stub(Main.prototype, 'init').resolves();
+    sandbox.stub(Main.prototype, 'workLoop').rejects(new Error('Main workLoop failed'));
 
     try {
       await main();
@@ -307,9 +317,9 @@ describe('main function', () => {
   });
 
   it('main function throws error when disconnecting fails', async () => {
-    sinon.stub(Main.prototype, 'init').resolves();
-    sinon.stub(Main.prototype, 'workLoop').resolves();
-    sinon.stub(Main.prototype, 'disconnect').rejects(new Error('Main disconnect failed'));
+    sandbox.stub(Main.prototype, 'init').resolves();
+    sandbox.stub(Main.prototype, 'workLoop').resolves();
+    sandbox.stub(Main.prototype, 'disconnect').rejects(new Error('Main disconnect failed'));
 
     try {
       await main();
@@ -325,9 +335,9 @@ describe('main function', () => {
   });
 
   it('main function works', async () => {
-    const initStub = sinon.stub(Main.prototype, 'init').resolves();
-    const workLoopStub = sinon.stub(Main.prototype, 'workLoop').resolves();
-    const disconnectStub = sinon.stub(Main.prototype, 'disconnect').resolves();
+    const initStub = sandbox.stub(Main.prototype, 'init').resolves();
+    const workLoopStub = sandbox.stub(Main.prototype, 'workLoop').resolves();
+    const disconnectStub = sandbox.stub(Main.prototype, 'disconnect').resolves();
 
     await main();
 


### PR DESCRIPTION
Break the Exporter class which encapsulates logic for both writing to Kafka and keeping state into two separate classes dealing with the two tasks respectively.