### PR TITLE
Multicall fixes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,7 +9,6 @@ slaveTemplates.dockerTemplate { label ->
     container('docker') {
       def scmVars = checkout scm
       def imageName = "san-chain-exporter"
-      def ghcrRegistry = "ghcr.io"
 
       stage('Run tests') {
         sh "./bin/test.sh"
@@ -18,21 +17,13 @@ slaveTemplates.dockerTemplate { label ->
       stage('Build image') {
         withCredentials([string(credentialsId: 'aws_account_id', variable: 'aws_account_id')]) {
           def awsRegistry = "${env.aws_account_id}.dkr.ecr.eu-central-1.amazonaws.com"
-          def imageVersion = "${env.BRANCH_NAME}".replaceAll('[-+/%_ ]','').toLowerCase()
-
-          sh "docker build \
-            -t ${awsRegistry}/${imageName}:${imageVersion} \
-            -t ${awsRegistry}/${imageName}:${scmVars.GIT_COMMIT} \
-            -t ${ghcrRegistry}/santiment/${imageName}:${imageVersion} \
-            -f docker/Dockerfile ."
-
           docker.withRegistry("https://${awsRegistry}", "ecr:eu-central-1:ecr-credentials") {
-            sh "docker push ${awsRegistry}/${imageName}:${imageVersion}"
+            sh "docker build \
+              -t ${awsRegistry}/${imageName}:${env.BRANCH_NAME} \
+              -t ${awsRegistry}/${imageName}:${scmVars.GIT_COMMIT} \
+              -f docker/Dockerfile ."
+            sh "docker push ${awsRegistry}/${imageName}:${env.BRANCH_NAME}"
             sh "docker push ${awsRegistry}/${imageName}:${scmVars.GIT_COMMIT}"
-          }
-
-          docker.withRegistry("https://${ghcrRegistry}", "ghcr-credentials") {
-            sh "docker push ${ghcrRegistry}/santiment/${imageName}:${imageVersion}"
           }
         }
       }

--- a/src/blockchains/erc20/lib/add_balances.ts
+++ b/src/blockchains/erc20/lib/add_balances.ts
@@ -33,21 +33,19 @@ function decodeMulticallResult(addressContractToMulticallResult: Utils.AddressCo
 
   const addressContract = addressContractToMulticallResult[0]
   const multicallResult = addressContractToMulticallResult[1]
-  logger.warn(JSON.stringify(addressContractToMulticallResult))
+
   if (multicallResult[0]) {
-    logger.info("Multicall result[0] is")
-    logger.info(multicallResult[1])
     try {
       const decoded: bigint = web3.eth.abi.decodeParameter('uint256', multicallResult[1]) as bigint
       return [blockNumber, addressContract[0], addressContract[1], decoded.toString(36)];
     }
     catch (error: any) {
-      logger.error(`Error decoding address-contract: ${addressContract[0]}-${addressContract[1]}: ${error}`)
+      logger.warn(`Error decoding address-contract: ${addressContract[0]}-${addressContract[1]}: ${error}`)
 
     }
   }
 
-  logger.error(`Multicall partial failure for address-contract ${addressContract[0]}-${addressContract[1]}`)
+  logger.warn(`Multicall partial failure for address-contract ${addressContract[0]}-${addressContract[1]}`)
   return [blockNumber, addressContract[0], addressContract[1], MULTICALL_FAILURE]
 }
 
@@ -80,7 +78,7 @@ async function executeNonBatchMulticall(web3: Web3, addressContracts: Utils.Addr
    * of 0s.
    */
   if (errors.length > 0) {
-    logger.error(`${errors.length} errors out of ${addressContracts.length} in multicall at block ${blockNumber}. First errors is: ${errors[0]}`);
+    logger.warn(`${errors.length} errors out of ${addressContracts.length} in multicall at block ${blockNumber}. First errors is: ${errors[0]}`);
   }
 
   return addressContracts.map((addressContract, index) => {
@@ -116,7 +114,6 @@ async function getBalancesPerBlock(web3: Web3, addressContracts: Utils.AddressCo
   let rawMulticallResult: Utils.AddressContractToMulticallResult[] = []
   try {
     rawMulticallResult = await executeBatchMulticall(web3, addressContracts, blockNumber)
-    logger.info("Batch multicall success")
   }
   catch (error: any) {
     logger.warn(`Error calling multicall at block ${blockNumber}, would try without batching`)
@@ -167,7 +164,6 @@ async function buildBalancesMap(web3: Web3, batchedAddresses: [number, Utils.Add
   for (const blockNumberAddress of batchedAddresses) {
     let result: Utils.BlockNumberAddressContractBalance[] = [];
     result = await getBalancesPerBlock(web3, blockNumberAddress[1], blockNumberAddress[0])
-    logger.info("Get balances per block done")
     results.push(...result)
   }
 

--- a/src/blockchains/erc20/lib/add_balances.ts
+++ b/src/blockchains/erc20/lib/add_balances.ts
@@ -114,34 +114,34 @@ async function getBalancesPerBlock(web3: Web3, addressContracts: Utils.AddressCo
   : Promise<Utils.BlockNumberAddressContractBalance[]> {
 
   let rawMulticallResult: Utils.AddressContractToMulticallResult[] = []
-  // try {
-  //   rawMulticallResult = await executeBatchMulticall(web3, addressContracts, blockNumber)
-  //   logger.info("Batch multicall success")
-  // }
-  // catch (error: any) {
-  //   logger.warn(`Error calling multicall at block ${blockNumber}, would try without batching`)
-  // }
+  try {
+    rawMulticallResult = await executeBatchMulticall(web3, addressContracts, blockNumber)
+    logger.info("Batch multicall success")
+  }
+  catch (error: any) {
+    logger.warn(`Error calling multicall at block ${blockNumber}, would try without batching`)
+  }
 
-  //if (rawMulticallResult.length === 0) {
-  rawMulticallResult = await executeNonBatchMulticall(web3, addressContracts, blockNumber)
-  return rawMulticallResult.map((rawResult: Utils.AddressContractToMulticallResult) => {
-    if (rawResult[1] === MULTICALL_FAILURE) {
-      // The balance call for this address-contract pair has failed. We would mark it as failure without decoding
-      return [blockNumber, rawResult[0][0], rawResult[0][1], MULTICALL_FAILURE]
-    }
-    else {
-      return decodeMulticallResult(rawResult, web3, blockNumber)
-    }
-  })
-  // if (error.cause.data) {
-  //   const decodedReason = Utils.decodeRevertReason(web3, error.cause.data);
-  //   logger.error('Revert reason:', decodedReason);
-  // }
+  if (rawMulticallResult.length === 0) {
+    rawMulticallResult = await executeNonBatchMulticall(web3, addressContracts, blockNumber)
+    return rawMulticallResult.map((rawResult: Utils.AddressContractToMulticallResult) => {
+      if (rawResult[1] === MULTICALL_FAILURE) {
+        // The balance call for this address-contract pair has failed. We would mark it as failure without decoding
+        return [blockNumber, rawResult[0][0], rawResult[0][1], MULTICALL_FAILURE]
+      }
+      else {
+        return decodeMulticallResult(rawResult, web3, blockNumber)
+      }
+    })
+    // if (error.cause.data) {
+    //   const decodedReason = Utils.decodeRevertReason(web3, error.cause.data);
+    //   logger.error('Revert reason:', decodedReason);
+    // }
 
-  //}
-  //else {*/
-  //return rawMulticallResult.map(rawResult => decodeMulticallResult(rawResult, web3, blockNumber))
-  //}
+  }
+  else {
+    return rawMulticallResult.map(rawResult => decodeMulticallResult(rawResult, web3, blockNumber))
+  }
 }
 
 //Get all addresses invovled in transfers. Map them to the block where the transfer happened.

--- a/src/blockchains/erc20/lib/add_balances.ts
+++ b/src/blockchains/erc20/lib/add_balances.ts
@@ -63,6 +63,22 @@ async function executeNonBatchMulticall(web3: Web3, addressContracts: Utils.Addr
 
   const errors = allSettled.filter(result => result.status === 'rejected').map(result => result.reason);
 
+  /**
+   * We allow for failed requests at this point. Some responses are just too long and seem like errors. Ex:
+   *
+   * curl -X POST https://ethereum.santiment.net -H "Content-Type: application/json" -d '{
+   * "jsonrpc": "2.0", "id": "1", "method": "eth_call", "params": [
+   *   {
+   *     "to": "0x5BA1e12693Dc8F9c48aAD8770482f4739bEeD696",
+   *     "data": "0xbce38bd70000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000020000000000000000000000000e2975f6a95735bdcad5e39296d37cab6470dacc80000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000002470a082310000000000000000000000007ac9368773c8d985c785ddda1964fa7c082cf89b00000000000000000000000000000000000000000000000000000000"
+   *   },
+   *     "0xd70c5d"
+   *   ]
+   *   }'
+   *
+   * This fails on our endpoint but succeeds on Ankr due to different limits. However the response is a long sequence
+   * of 0s.
+   */
   if (errors.length > 0) {
     logger.error(`${errors.length} errors out of ${addressContracts.length} in multicall at block ${blockNumber}. First errors is: ${errors[0]}`);
   }

--- a/src/blockchains/erc20/lib/add_balances.ts
+++ b/src/blockchains/erc20/lib/add_balances.ts
@@ -130,11 +130,6 @@ async function getBalancesPerBlock(web3: Web3, addressContracts: Utils.AddressCo
         return decodeMulticallResult(rawResult, web3, blockNumber)
       }
     })
-    // if (error.cause.data) {
-    //   const decodedReason = Utils.decodeRevertReason(web3, error.cause.data);
-    //   logger.error('Revert reason:', decodedReason);
-    // }
-
   }
   else {
     return rawMulticallResult.map(rawResult => decodeMulticallResult(rawResult, web3, blockNumber))

--- a/src/blockchains/erc20/lib/balance_utils.ts
+++ b/src/blockchains/erc20/lib/balance_utils.ts
@@ -6,6 +6,7 @@ import { ZERO_ADDRESS } from './fetch_events';
 export type AddressContractToBalance = Map<string, string>;
 export type AddressContract = [string, string]
 export type BlockNumberAddressContractBalance = [number, string, string, string]
+export type AddressContractToMulticallResult = [AddressContract, any]
 
 
 export function decodeRevertReason(web3: Web3, errorData: string) {

--- a/src/blockchains/erc20/lib/balance_utils.ts
+++ b/src/blockchains/erc20/lib/balance_utils.ts
@@ -9,16 +9,6 @@ export type BlockNumberAddressContractBalance = [number, string, string, string]
 export type AddressContractToMulticallResult = [AddressContract, any]
 
 
-export function decodeRevertReason(web3: Web3, errorData: string) {
-  try {
-    return web3.eth.abi.decodeParameter('string', '0x' + errorData.slice(10));
-  } catch (e) {
-    return 'Unable to decode error data';
-  }
-}
-
-
-
 export function addToSet(set: AddressContractStore, event: ERC20Transfer) {
   if (isAddressEligableForBalance(event.from, event.contract)) {
     set.add([event.from, event.contract]);

--- a/src/test/erc20/add_balances.spec.ts
+++ b/src/test/erc20/add_balances.spec.ts
@@ -222,18 +222,6 @@ describe('test execute Multicall', function () {
   it('test executeNonBatchMulticall', async function () {
 
     const mockedResult = { "0": true, "1": "0x000000000000000000000000000000000000000000000000000001f935735eb8", "__length__": 2, "success": true, "returnData": "0x000000000000000000000000000000000000000000000000000001f935735eb8" };
-    //{ "0": true, "1": "0x00000000000000000000000000000000000000000000000000000000008aff7a", "__length__": 2, "success": true, "returnData": "0x00000000000000000000000000000000000000000000000000000000008aff7a" },
-    //{ "0": true, "1": "0x0000000000000000000000000000000000000000000000000000000000000000", "__length__": 2, "success": true, "returnData": "0x0000000000000000000000000000000000000000000000000000000000000000" },
-    //{ "0": true, "1": "0x000000000000000000000000000000000000000000000167e12893baf0a00881", "__length__": 2, "success": true, "returnData": "0x000000000000000000000000000000000000000000000167e12893baf0a00881" },
-
-
-    // const mockedResult = [
-    //   { "0": true, "1": "0x000000000000000000000000000000000000000000000000000001f935735eb8", "__length__": 2, "success": true, "returnData": "0x000000000000000000000000000000000000000000000000000001f935735eb8" },
-    //   { "0": true, "1": "0x00000000000000000000000000000000000000000000000000000000008aff7a", "__length__": 2, "success": true, "returnData": "0x00000000000000000000000000000000000000000000000000000000008aff7a" },
-    //   { "0": true, "1": "0x0000000000000000000000000000000000000000000000000000000000000000", "__length__": 2, "success": true, "returnData": "0x0000000000000000000000000000000000000000000000000000000000000000" },
-    //   { "0": true, "1": "0x000000000000000000000000000000000000000000000167e12893baf0a00881", "__length__": 2, "success": true, "returnData": "0x000000000000000000000000000000000000000000000167e12893baf0a00881" },
-    // ];
-
 
     // One address resolves the other fails
     const doMulticallMock = sinon.stub().callsFake((web3: any, blockNumber: number, addressContract: Utils.AddressContract[]) => {
@@ -256,8 +244,34 @@ describe('test execute Multicall', function () {
     const addressContracts = [addressContract1, addressContract2]
     const result: Utils.AddressContractToMulticallResult[] = await executeNonBatchMulticall(null, addressContracts, 1);
 
-    console.log(`Result is: ${JSON.stringify(result)}`)
     const expected = [[addressContract1, MULTICALL_FAILURE], [addressContract2, mockedResult]]
+
+    assert.deepStrictEqual(result, expected)
+  });
+
+  it('test executeBatchMulticall', async function () {
+
+    const multicallResultAddress1 = { "0": true, "1": "0x000000000000000000000000000000000000000000000000000001f935735eb8", "__length__": 2, "success": true, "returnData": "0x000000000000000000000000000000000000000000000000000001f935735eb8" };
+    const multicallResultAddress2 = { "0": true, "1": "0x00000000000000000000000000000000000000000000000000000000008aff7a", "__length__": 2, "success": true, "returnData": "0x00000000000000000000000000000000000000000000000000000000008aff7a" };
+
+
+    const doMulticallMock = sinon.stub().callsFake((web3: any, blockNumber: number, addressContract: Utils.AddressContract[]) => {
+      assert.equal(addressContract.length, 2)
+
+      return Promise.resolve([multicallResultAddress1, multicallResultAddress2]);
+    });
+
+
+    add_balances_rewired.__set__('doMulticall', doMulticallMock);
+
+    const executeBatchMulticall = add_balances_rewired.__get__('executeBatchMulticall');
+    const addressContract1 = ["address1", "contract1"]
+    const addressContract2 = ["address2", "contract2"]
+
+    const addressContracts = [addressContract1, addressContract2]
+    const result: Utils.AddressContractToMulticallResult[] = await executeBatchMulticall(null, addressContracts, 1);
+
+    const expected = [[addressContract1, multicallResultAddress1], [addressContract2, multicallResultAddress2]]
 
     assert.deepStrictEqual(result, expected)
   });


### PR DESCRIPTION
The Multicall [implementation](https://github.com/santiment/san-chain-exporter/pull/202) has been catching up on historic data up until it hit a problem where we got RPC response too big error. Some get balance responses would be too big and fail on default Ethereum Node setup with error about RPC response size being too big. Those responses look to be like either error or malicious, I think we can skip those.