### PR TITLE
Interpret broken event where data is only '0x' as 0

### DIFF
--- a/src/blockchains/eth/lib/web3_wrapper.ts
+++ b/src/blockchains/eth/lib/web3_wrapper.ts
@@ -14,6 +14,12 @@ export interface Web3Interface {
     gweiToWei(amount: string): number;
 }
 
+function containsOnly0Andx(input: string) {
+    const chars = Array.from(input);
+
+    return chars.length > 0 && chars.every(char => char === '0' || char === 'x' || char === 'X');
+}
+
 export class Web3Wrapper implements Web3Interface {
     private web3: Web3;
     private lastBlockNumber: number;
@@ -31,7 +37,13 @@ export class Web3Wrapper implements Web3Interface {
      * Converts value to it's number representation. Returns bigint or number depending on value.
      */
     parseHexToNumber(field: string): number | bigint {
-        return this.web3.utils.hexToNumber(field);
+        // We want to interpret values which are not technically correct as 0. For example '0x'.
+        if (containsOnly0Andx(field)) {
+            return 0
+        }
+        else {
+            return this.web3.utils.hexToNumber(field);
+        }
     }
 
     parseNumberToHex(field: number): string {

--- a/src/test/erc20/fetch_events.spec.ts
+++ b/src/test/erc20/fetch_events.spec.ts
@@ -466,3 +466,44 @@ describe('getEventsByTransactionTest', function () {
     assert.deepStrictEqual(result[1], [decodedEvent0, decodedEvent1]);
   });
 });
+
+
+describe('decodeBrokenEventTest', function () {
+  const decodeTransferEvent = fetch_events.__get__('decodeTransferEvent');
+
+  // A broken event on the Polygon chain where data is only "0x"
+  const brokenEventToDecode = {
+    "address": "0xb9b4856d9dbe659cf16891c735797bbf5b7cc530",
+    "topics": [
+      "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
+      "0x0000000000000000000000001234567890123456789012345678901234567890",
+      "0x0000000000000000000000009876543210987654321098765432109876543210"
+    ],
+    "data": "0x",
+    "blockNumber": 7207279,
+    "transactionHash": "0xda7953e0b756ddff528c1b9b74d0dff9f51298a6d8bdab8d592b76e9693d6a15",
+    "transactionIndex": 142,
+    "blockHash": "0x65c70fdf03e8aa957572f54756ad30508af9d48188e7d14bf2d80e33592b5480",
+    "logIndex": 596,
+    "removed": false
+
+  }
+
+  it('ensures data containing only 0x is decoded as 0', async function () {
+    const result = decodeTransferEvent(web3Wrapper, brokenEventToDecode, new TimestampsCacheMock())
+
+    const expected = {
+      "blockNumber": 7207279,
+      "transactionHash": "0xda7953e0b756ddff528c1b9b74d0dff9f51298a6d8bdab8d592b76e9693d6a15",
+      "logIndex": 596,
+      "contract": "0xb9b4856d9dbe659cf16891c735797bbf5b7cc530",
+      "to": "0x9876543210987654321098765432109876543210",
+      "from": "0x1234567890123456789012345678901234567890",
+      "value": 0,
+      "valueExactBase36": "0",
+      "timestamp": 1549899997
+    }
+
+    assert.deepStrictEqual(result, expected);
+  });
+});


### PR DESCRIPTION
Hot fix :hot_pepper:. Polygon ERC20 exporting has stopped due to this event:

https://polygonscan.com/tx/0xda7953e0b756ddff528c1b9b74d0dff9f51298a6d8bdab8d592b76e9693d6a15

containing this field:

`'data': '0x'`

the Web3JS library complains that this is not a valid hex. The fix we do handles it as 0.