### PR TITLE
Cardano supports block interval

### DIFF
--- a/src/blockchains/cardano/lib/constants.ts
+++ b/src/blockchains/cardano/lib/constants.ts
@@ -1,4 +1,6 @@
 export const CONFIRMATIONS = parseInt(process.env.CONFIRMATIONS || '3');
 export const LOOP_INTERVAL_CURRENT_MODE_SEC = parseInt(process.env.LOOP_INTERVAL_CURRENT_MODE_SEC || '30');
 export const NODE_REQUEST_RETRY = parseInt(process.env.NODE_REQUEST_RETRY || '5');
-
+export const BLOCK_INTERVAL = parseInt(process.env.BLOCK_INTERVAL || '1000');
+export const CARDANO_GRAPHQL_URL = process.env.CARDANO_GRAPHQL_URL || 'http://localhost:3100/graphql';
+export const DEFAULT_TIMEOUT_MSEC = parseInt(process.env.DEFAULT_TIMEOUT || '30000');


### PR DESCRIPTION
Support block interval in Cardano exporter. 

The Cardano exporter uses GraphQL to fetch transactions. It is not necessary to specify end block, as the API would return as many blocks as can fit in the response. However adding the interval allows for better debugging when we want to fetch less data than the maximum.