### PR TITLE
Add primary keys also to EOB events

### DIFF
--- a/src/blockchains/eth/eth_worker.ts
+++ b/src/blockchains/eth/eth_worker.ts
@@ -105,17 +105,18 @@ export class ETHWorker extends BaseWorker {
     logger.info(`Fetching transfer events for interval ${fromBlock}:${toBlock}`)
     const [traces, blocks, receipts] = await this.fetchData(fromBlock, toBlock)
     const events: (ETHTransfer | EOB)[] = this.transformPastEvents(fromBlock, toBlock, traces, blocks, receipts)
+    events.push(...collectEndOfBlocks(fromBlock, toBlock, blocks, this.web3Wrapper))
+
     if (this.settings.ASSIGN_INTERNAL_TX_POSITION) {
       assignInternalTransactionPosition(events)
+      events.sort(transactionOrder)
     }
     else {
+      events.sort(transactionOrder)
       extendEventsWithPrimaryKey(events, this.lastPrimaryKey);
 
       this.lastPrimaryKey += events.length;
     }
-
-    events.push(...collectEndOfBlocks(fromBlock, toBlock, blocks, this.web3Wrapper))
-    events.sort(transactionOrder)
 
     this.lastExportedBlock = toBlock
 


### PR DESCRIPTION
Bugfix to a problem which got introduced in the [previous PR](https://github.com/santiment/san-chain-exporter/pull/212). As result primary keys were not being assigned to the meta EOB events that we generate.

Before this fix:

`CreateTime:1736254200278	null	{"from":"0x0000000000000000000000000000000000000000","to":"0x0000000000000000000000000000000000000000","value":0,"valueExactBase36":"0","blockNumber":21572696,"timestamp":1736254151,"transactionHash":"0x0000000000000000000000000000000000000000","transactionPosition":2147483647,"internalTxPosition":0,"type":"EOB"}`

After this fix:

`CreateTime:1736254300850	6102417608	{"from":"0x0000000000000000000000000000000000000000","to":"0x0000000000000000000000000000000000000000","value":0,"valueExactBase36":"0","blockNumber":21572703,"timestamp":1736254235,"transactionHash":"0x0000000000000000000000000000000000000000","transactionPosition":2147483647,"internalTxPosition":0,"type":"EOB","primaryKey":6102417608}
`

Difference is that the primary key was being left as 'null' before