### PR TITLE
Add logIndex as part of sort key

### DIFF
--- a/src/blockchains/erc20/erc20_worker.ts
+++ b/src/blockchains/erc20/erc20_worker.ts
@@ -177,6 +177,9 @@ export class ERC20Worker extends BaseWorker {
         if (blockDif !== 0) {
           return blockDif;
         }
+        else if (a.logIndex !== b.logIndex) {
+          return a.logIndex - b.logIndex;
+        }
         if (typeof a.primaryKey !== 'number' || typeof b.primaryKey !== 'number') {
           throw Error('Primary keys should be set to number before event')
         }


### PR DESCRIPTION
* For completeness add logIndex as part of sort key
* It has already been used to construct primary key, but let's be safe even if primary key construction is corrupt.

Related to:
https://github.com/santiment/san-chain-exporter/pull/216