### PR TITLE
Allow exception for block with no transfers

### DIFF
--- a/src/blockchains/eth/lib/util.ts
+++ b/src/blockchains/eth/lib/util.ts
@@ -35,12 +35,22 @@ export function assignInternalTransactionPosition(transfers: ETHTransfer[], grou
 
 export function assertBlocksMatch(groupedTransfers: any, fromBlock: number, toBlock: number) {
   const keys = Object.keys(groupedTransfers)
-  if (keys.length !== toBlock - fromBlock + 1) {
-    throw new Error(`Wrong number of blocks seen. Expected ${toBlock - fromBlock + 1} got ${keys.length}.`)
+
+  const blocksExceptionList = [15537454]
+  let blocksExpected = toBlock - fromBlock + 1
+
+  for (const blockException of blocksExceptionList) {
+    if (blockException >= fromBlock && blockException <= toBlock) {
+      --blocksExpected;
+    }
+  }
+
+  if (keys.length !== blocksExpected) {
+    throw new Error(`Wrong number of blocks seen. Expected ${blocksExpected} got ${keys.length}.`)
   }
 
   for (let block = fromBlock; block <= toBlock; block++) {
-    if (!groupedTransfers.hasOwnProperty(block.toString())) {
+    if (!blocksExceptionList.includes(block) && !groupedTransfers.hasOwnProperty(block.toString())) {
       throw new Error(`Missing transfers for block ${block}.`)
     }
   }

--- a/src/blockchains/eth/lib/util.ts
+++ b/src/blockchains/eth/lib/util.ts
@@ -36,6 +36,7 @@ export function assignInternalTransactionPosition(transfers: ETHTransfer[], grou
 export function assertBlocksMatch(groupedTransfers: any, fromBlock: number, toBlock: number) {
   const keys = Object.keys(groupedTransfers)
 
+  // A list of empty blocks, no transfers and no rewards.
   const blocksExceptionList = [15537454]
   let blocksExpected = toBlock - fromBlock + 1
 

--- a/src/test/eth/util.spec.ts
+++ b/src/test/eth/util.spec.ts
@@ -306,6 +306,15 @@ describe('checkETHTransfersQuality', () => {
 
         expect(() => checkETHTransfersQuality(transfers, 102, 103)).toThrow()
     })
+
+    it('Do not throw an error when data for whitelisted contract is missing', () => {
+        const transfers: ETHTransfer[] = [
+            createTransfer('A', 'B', 1, 15537453, "hash", 0),
+            createTransfer('C', 'D', 2, 15537455, "hash", 0)
+        ];
+
+        expect(() => checkETHTransfersQuality(transfers, 15537453, 15537455)).not.toThrow()
+    })
 });
 
 


### PR DESCRIPTION
We've came across a block which has no transfers and no rewards. We don't fully understand why no rewards were attributes at this block and expect this to be an exception. So this block has been whitelisted.