### PR TITLE
Produce 'master' images out of tagged ones

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,42 @@
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+template: |
+  # What's Changed
+
+  $CHANGES
+
+  **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION
+
+categories:
+  - title: 'Breaking'
+    label: 'type: breaking'
+  - title: 'New'
+    label: 'type: feature'
+  - title: 'Bug Fixes'
+    label: 'type: bug'
+  - title: 'Maintenance'
+    label: 'type: maintenance'
+  - title: 'Documentation'
+    label: 'type: docs'
+  - title: 'Other changes'
+  - title: 'Dependency Updates'
+    label: 'type: dependencies'
+    collapse-after: 5
+
+version-resolver:
+  major:
+    labels:
+      - 'type: breaking'
+  minor:
+    labels:
+      - 'type: feature'
+  patch:
+    labels:
+      - 'type: bug'
+      - 'type: maintenance'
+      - 'type: docs'
+      - 'type: dependencies'
+      - 'type: security'
+
+exclude-labels:
+  - 'skip-changelog'

--- a/.github/workflows/draft.yml
+++ b/.github/workflows/draft.yml
@@ -1,0 +1,14 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,16 +14,45 @@ slaveTemplates.dockerTemplate { label ->
         sh "./bin/test.sh"
       }
 
+      def tag               = sh(returnStdout: true, script: "git tag --contains | head -1").trim()
+      def isTagDefined      = tag != null && tag.length() > 1
+      def isProductionBuild = false
+      if(isTagDefined) { // expect all tags were fetched by scm
+        def latestTag     = sh(returnStdout: true, script: "git describe --tags --abbrev=4").trim()
+        isProductionBuild = isTagDefined && tag == latestTag
+      }
+    def branch            = env.BRANCH_NAME
+    def branchNameSanitized = "${env.BRANCH_NAME}".split('/').last()
+
       stage('Build image') {
         withCredentials([string(credentialsId: 'aws_account_id', variable: 'aws_account_id')]) {
           def awsRegistry = "${env.aws_account_id}.dkr.ecr.eu-central-1.amazonaws.com"
           docker.withRegistry("https://${awsRegistry}", "ecr:eu-central-1:ecr-credentials") {
             sh "docker build \
-              -t ${awsRegistry}/${imageName}:${env.BRANCH_NAME} \
+              -t ${awsRegistry}/${imageName}:${branchNameSanitized} \
               -t ${awsRegistry}/${imageName}:${scmVars.GIT_COMMIT} \
               -f docker/Dockerfile ."
-            sh "docker push ${awsRegistry}/${imageName}:${env.BRANCH_NAME}"
+            sh "docker push ${awsRegistry}/${imageName}:${branchNameSanitized}"
             sh "docker push ${awsRegistry}/${imageName}:${scmVars.GIT_COMMIT}"
+          }
+
+          if(branch == 'master' || branch == 'main') {
+              sh """
+                  docker tag ${awsRegistry}/${imageName}:${scmVars.GIT_COMMIT} ${awsRegistry}/${imageName}:stage;
+                  docker push ${awsRegistry}/${imageName}:stage
+              """
+          }
+          if(isProductionBuild) {
+              sh """
+                  docker tag ${awsRegistry}/${imageName}:${scmVars.GIT_COMMIT} ${awsRegistry}/${imageName}:production;
+                  docker push ${awsRegistry}/${imageName}:production
+              """
+          }
+          if (isTagDefined) {
+              sh """
+                  docker tag ${awsRegistry}/${imageName}:${scmVars.GIT_COMMIT} ${awsRegistry}/${imageName}:${tag};
+                  docker push ${awsRegistry}/${imageName}:${tag}
+              """
           }
         }
       }


### PR DESCRIPTION
* Extend the Jenkinsfile logic so that it tags new images with 'production' or 'staging' tag if they match corresponding conditions. This logic was done by "Deploy to Stage" and "Deploy to Production" pipelines in Jenkins, but now we may release new production images using Github's 'Release' section.
* The syntax mostly has been copied from Jenkinsfile in `clickhouse-tables` repository.
* Github actions for creating a Release draft.