### PR TITLE
'totalDifficulty' would be missing on new blocks

### DIFF
--- a/src/blockchains/eth/eth_types.ts
+++ b/src/blockchains/eth/eth_types.ts
@@ -45,7 +45,7 @@ export type ETHBlock = {
   miner: string,
   number: string,
   timestamp: string,
-  totalDifficulty: string,
+  totalDifficulty?: string,
   difficulty: string,
   size: string,
   minGasPrice?: string

--- a/src/blockchains/eth_blocks/eth_blocks_worker.ts
+++ b/src/blockchains/eth_blocks/eth_blocks_worker.ts
@@ -27,7 +27,7 @@ export class ETHBlocksWorker extends BaseWorker {
       hash: block.hash,
       miner: block.miner,
       difficulty: Web3Static.parseHexToNumberString(block.difficulty),
-      totalDifficulty: Web3Static.parseHexToNumberString(block.totalDifficulty),
+      totalDifficulty: Web3Static.parseHexToNumberString(block.totalDifficulty !== undefined ? block.totalDifficulty : '0x0'),
       timestamp: safeCastToNumber(Web3Static.parseHexToNumber(block.timestamp)),
       size: safeCastToNumber(Web3Static.parseHexToNumber(block.size)),
       gasLimit: safeCastToNumber(Web3Static.parseHexToNumber(block.gasLimit)),


### PR DESCRIPTION
In this PR - make 'totalDifficulty' field optional. We would see it on old blocks but not on new ones. New Erigon versions do not return 'totalDifficulty' field. This field is related to POW consensus algorithm and is no longer relevant. Older Erigon versions returned it ever for new blocks, from what I've read they've returned the difficulty of the last POW block, but Erigon v3 has stopped returning it.