### PR TITLE
Option to disable Kafka producer sticky partition

### DIFF
--- a/src/e2e/producer-transaction.spec.ts
+++ b/src/e2e/producer-transaction.spec.ts
@@ -117,7 +117,7 @@ describe('Producer transactions', function () {
     // consumer but there is something I am missing.
     setTimeout(async function () {
       for (let i = 0; i < num_messages_test; i++) {
-        exporter.sendDataWithKey({
+        exporter.sendData({
           timestamp: 10000000,
           iso_date: new Date().toISOString(),
           key: 1

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -13,4 +13,5 @@ export const START_PRIMARY_KEY = getIntEnvVariable('START_PRIMARY_KEY', -1);
 export const WRITE_SIGNAL_RECORDS_KAFKA = getBoolEnvVariable('WRITE_SIGNAL_RECORDS_KAFKA', false);
 export const KAFKA_TOPIC = process.env.KAFKA_TOPIC;
 export const TEST_ENV = getBoolEnvVariable('TEST_ENV', false);
+export const KAFKA_PRODUCER_DISABLE_STICKY_PARTITION = getBoolEnvVariable('KAFKA_PRODUCER_DISABLE_STICKY_PARTITION', false);
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -27,9 +27,9 @@ export class Main {
     ))
   }
 
-  async initExporter(exporterName: string, isTransactions: boolean, kafkaTopic: string) {
+  async initExporter(exporterName: string, isTransactions: boolean, kafkaTopic: string, disableStickyPartition: boolean) {
     const INIT_EXPORTER_ERR_MSG = 'Error when initializing exporter: ';
-    this.exporter = new Exporter(exporterName, isTransactions, kafkaTopic);
+    this.exporter = new Exporter(exporterName, isTransactions, kafkaTopic, disableStickyPartition);
     await this.exporter
       .connect()
       .then(() => this.exporter.initTransactions())
@@ -70,7 +70,7 @@ export class Main {
   async init(blockchain: string) {
     const blockchainSpecificConstants = require(`./blockchains/${blockchain}/lib/constants`);
     const mergedConstants = { ...constantsBase, ...blockchainSpecificConstants };
-    await this.initExporter(EXPORTER_NAME, true, mergedConstants.KAFKA_TOPIC);
+    await this.initExporter(EXPORTER_NAME, true, mergedConstants.KAFKA_TOPIC, mergedConstants.KAFKA_PRODUCER_DISABLE_STICKY_PARTITION);
     await this.initWorker(blockchain, mergedConstants);
     metrics.startCollection();
 


### PR DESCRIPTION
In this PR we make it configurable to disable Kafka producer 'sticky partition'.

When we don't provide an explicit partition (and key record is null) the Kafka producer would do roundrobin. However it would also apply a 'sticky partition' concept where it batches record and send them in the same partition and only then move to the next one. This sticky behavior is intended to improve performance, however in our case we want to shuffle records as good as possible across partitions, ideally we want to have a record for a block number written in all partitions. Reason for this is downstream consumer Flink, 'sticky' behavior results in all records for a block landing in same partition, then Flink needs to wait for data to arrive in other partitions and this adds artitifical delay in our processing. Flink watermarks dashbord visualizes this problem:

![image](https://github.com/user-attachments/assets/a0edc585-b5b0-460b-9d92-838291ee9f94)

What we see here is that some sources have new data but not all, and the global Watermark is choppy instead of smooth. Disabling sticky behavior we end up with this chart:

![image](https://github.com/user-attachments/assets/9a11c828-966f-49d4-af88-608a4915364e)

(the right part)
