### PR TITLE
Internal transaction position offers full ordering

### DIFF
--- a/src/blockchains/eth/lib/util.ts
+++ b/src/blockchains/eth/lib/util.ts
@@ -23,7 +23,7 @@ export function transactionOrder(a: ETHTransfer | EOB, b: ETHTransfer | EOB) {
   return internalTxPositionA - internalTxPositionB
 }
 
-const ethTransferKey = (transfer: ETHTransfer) => `${transfer.blockNumber}-${transfer.transactionHash ?? ''}-${transfer.transactionPosition ?? ''}-${transfer.from}-${transfer.to}`
+const ethTransferKey = (transfer: ETHTransfer) => `${transfer.blockNumber}-${transfer.transactionHash ?? ''}`
 
 export function assignInternalTransactionPosition(transfers: ETHTransfer[], groupByKey: (transfer: ETHTransfer) => string = ethTransferKey): void {
   const grouped = groupBy(transfers, groupByKey)

--- a/src/lib/kafka_storage.ts
+++ b/src/lib/kafka_storage.ts
@@ -369,8 +369,10 @@ export class Exporter {
     try {
       if (BLOCKCHAIN === 'utxo') {
         await this.sendData(events, 'height', signalRecord);
-      } else if (BLOCKCHAIN === 'receipts' || BLOCKCHAIN === 'eth') {
+      } else if (BLOCKCHAIN === 'receipts') {
         await this.sendData(events, 'transactionHash', signalRecord);
+      } else if (BLOCKCHAIN === 'eth') {
+        await this.sendData(events, null, signalRecord);
       }
       else {
         await this.sendData(events, 'primaryKey', signalRecord);


### PR DESCRIPTION
* In a [previous change](https://github.com/santiment/san-chain-exporter/pull/212) we moved away from using a global incrementing primary key to adding an 'internal transaction position'. That is when two transfers have identical
`(block number, transaction id, from, to)` we would increment the internal transaction position to create uniqueness. The new field would remain 0 otherwise. 
* The above implementation is sufficient in the context of Clickhouse tables, also for generating ETH balances, however one usage I failed to consider is the ETH stacks job. In this job if an address' funds change twice inside single transaction we consider those two changes separately and do not aggregate. For this to work correctly we need ordering among the two changes. The above implementation does not define an ordering across the whole transaction. If we have
`(block number = 10, transaciton id = "tx id", from = "A", to = "B")` and
`(block number = 10, transaciton id = "tx id", from = "C", to = "A")`
the two changes on the assets of A are in no relation.
* In the new implementation part of this PR, we increment the internal tx position for all transfers within the same `(block number, transaction id)`. The order matches the order received from the Node.