### PR TITLE
Internal tx position is assigned for same tx

### DIFF
--- a/src/blockchains/eth/lib/util.ts
+++ b/src/blockchains/eth/lib/util.ts
@@ -23,7 +23,7 @@ export function transactionOrder(a: ETHTransfer | EOB, b: ETHTransfer | EOB) {
   return internalTxPositionA - internalTxPositionB
 }
 
-const ethTransferKey = (transfer: ETHTransfer) => `${transfer.blockNumber}-${transfer.transactionHash ?? ''}`
+const ethTransferKey = (transfer: ETHTransfer) => `${transfer.blockNumber}-${transfer.transactionPosition ?? ''}`
 
 export function assignInternalTransactionPosition(transfers: ETHTransfer[], groupByKey: (transfer: ETHTransfer) => string = ethTransferKey): void {
   const grouped = groupBy(transfers, groupByKey)

--- a/src/test/eth/util.spec.ts
+++ b/src/test/eth/util.spec.ts
@@ -208,6 +208,41 @@ describe('assignInternalTransactionPosition utils', () => {
         assignInternalTransactionPosition(transfers)
         expect(transfers).toEqual(expected)
     })
+
+    it('same tx position, different tx hash is assigned correctly', () => {
+        // Records shoud be equal based on 'group by' criteria. Expect to get grouped.
+        // 'group by' criteria should consider transaction position and transaction hash.
+        const transfers: ETHTransfer[] = [{
+            from: "mining_uncle",
+            to: "toAddress",
+            value: 100,
+            valueExactBase36: "2S",
+            blockNumber: 2,
+            timestamp: 1000,
+            transactionHash: "mining_uncle",
+            transactionPosition: 0,
+            internalTxPosition: 0,
+            type: "type"
+        },
+        {
+            from: "fromAddress",
+            to: "toAddress",
+            value: 50,
+            valueExactBase36: "1S",
+            blockNumber: 2,
+            timestamp: 1000,
+            transactionHash: "hash",
+            transactionPosition: 0,
+            internalTxPosition: 0,
+            type: "type"
+        }]
+        const expected = cloneDeep(transfers)
+        expected[0].internalTxPosition = 0
+        expected[1].internalTxPosition = 1
+
+        assignInternalTransactionPosition(transfers)
+        expect(transfers).toEqual(expected)
+    })
 })
 
 // Helper function to create ETHTransfer objects


### PR DESCRIPTION
* Some aritifical transfers we generate have tx position set to 0 even though 'transactionHash' is unique.
* When assigning internal tx position we should consider the tx position and not the transacitonHash because this is based on what Flink would deduplicate.

The problem appears for records like this:

```
{"from":"0x109c4f2ccc82c4d77bde15f306707320294aea3f","to":"0xfd2605a2bf58fdbb90db1da55df61628b47f9e8c","value":500000000000000000,"valueExactBase36":"3sr77gzykagw","blockNumber":50324,"timestamp":1438987309,"transactionHash":"0x22591c7aadb705df30a13e97f73496b529f208573a231c7eb389766d29b421d1","transactionPosition":0,"internalTxPosition":1,"type":"call"}
{"from":"mining_block","to":"0x3f113041d56dda809a245fe338832c2d373e7c80","value":5000000000000000000,"valueExactBase36":"11zk02pzlmwow","blockNumber":50324,"timestamp":1438987309,"transactionHash":"mining_block","transactionPosition":0,"internalTxPosition":0,"type":"reward"}
```