### PR TITLE
Remove epoch _is_null filter from Cardano transactions query

### DIFF
--- a/src/blockchains/cardano/cardano_worker.ts
+++ b/src/blockchains/cardano/cardano_worker.ts
@@ -117,7 +117,6 @@ export class CardanoWorker extends BaseWorker {
     const query = `{
     transactions(
        where: {
-         block: { epoch: { number: { _is_null: false } } }
          _and: [
            { block: { number: { _gte: ${fromBlock} } } },
            { block: { number: { _lte: ${toBlock} } } }


### PR DESCRIPTION
## Summary

Removes the `block: { epoch: { number: { _is_null: false } } }` clause from the `where` filter in `CardanoWorker.getTransactions()`.

## Why

The epoch filter forces Hasura to evaluate the `"Epoch"` view for every candidate row. On the new schema (cardano-graphql 9.0.1 / db-sync 13.7.2.1), that view recomputes the current in-progress epoch's stats live via a full sequential scan of the entire `block` table (~13.6M rows) on every call, regardless of how small the requested block range is.

Measured on a 20-block range against the same chain tip:

| Query | new schema |
|---|---|
| `transactions(...)` **with** epoch filter | ~270,000–300,000 ms (~4.5–5 min) |
| `transactions(...)` **without** epoch filter | **153 ms** |

## Why it's safe

- The filter only existed to guard against genesis transfers, which have a null block number. Those are fetched by the separate `getGenesisTransactionsPage()` path (filtered by genesis block hash) and never go through `getTransactions()`.
- Even without that, NULL block numbers can never satisfy the `_gte`/`_lte` range conditions, so the range filter alone already excludes genesis rows. The epoch clause never excluded anything — it only added cost.
- The `epochNo` field in the selection set is unaffected: it maps to the plain `epoch_no` column on `block` and does not touch the expensive `"Epoch"` view.
- Verified the query returns the same transactions with and without the filter.
- The existing `discardNotCompletedBlock` / `verifyAllBlocksComplete` checks validate per-block transaction counts at runtime as an additional safety net.

## Test plan

- `tsc --noEmit` passes
- All 11 Cardano unit tests pass (`src/test/cardano/`)
- Query equivalence verified manually against both the legacy and new cardano-graphql schemas

🤖 Generated with [Claude Code](https://claude.com/claude-code)