### PR TITLE
ERC20: handle blocks exceeding the node eth_getLogs limit

### DIFF
--- a/src/blockchains/erc20/lib/fetch_events.ts
+++ b/src/blockchains/erc20/lib/fetch_events.ts
@@ -234,6 +234,28 @@ export async function getPastEvents(web3Wrapper: Web3Interface, fromBlock: numbe
 }
 
 
+function isTooManyLogsError(error: any): boolean {
+  const message = String(error?.message ?? error);
+  return /too many logs|more than \d+ (results|logs)/i.test(message);
+}
+
+// Fetch all logs of a single block through eth_getBlockReceipts, which is not subject
+// to the node's eth_getLogs response limit.
+async function getRawEventsFromReceipts(web3Wrapper: Web3Interface, blockNumber: number,
+  contractAddress: string | string[] | null): Promise<RawEvent[]> {
+  const receipts = await web3Wrapper.getBlockReceipts(blockNumber);
+  let logs: RawEvent[] = receipts.flatMap((receipt: any) => receipt.logs ?? []);
+
+  if (contractAddress) {
+    const allowed = new Set(
+      (Array.isArray(contractAddress) ? contractAddress : [contractAddress]).map(a => a.toLowerCase())
+    );
+    logs = logs.filter(log => allowed.has(log.address.toLowerCase()));
+  }
+
+  return logs;
+}
+
 async function getRawEvents(web3Wrapper: Web3Interface, fromBlock: number, toBlock: number, contractAddress: string | string[] | null): Promise<RawEvent[]> {
   let queryObject: any = {
     fromBlock: Web3Static.parseNumberToHex(fromBlock),
@@ -247,7 +269,24 @@ async function getRawEvents(web3Wrapper: Web3Interface, fromBlock: number, toBlo
     queryObject.address = contractAddress;
   }
 
-  return await web3Wrapper.getPastLogs(queryObject);
+  try {
+    return await web3Wrapper.getPastLogs(queryObject);
+  } catch (error) {
+    if (!isTooManyLogsError(error)) {
+      throw error;
+    }
+
+    if (fromBlock === toBlock) {
+      logger.info(`Block ${fromBlock} exceeds the node eth_getLogs limit, falling back to eth_getBlockReceipts`);
+      return await getRawEventsFromReceipts(web3Wrapper, fromBlock, contractAddress);
+    }
+
+    const middle = Math.floor((fromBlock + toBlock) / 2);
+    logger.info(`Interval ${fromBlock}:${toBlock} exceeds the node eth_getLogs limit, splitting at ${middle}`);
+    const firstHalf = await getRawEvents(web3Wrapper, fromBlock, middle, contractAddress);
+    const secondHalf = await getRawEvents(web3Wrapper, middle + 1, toBlock, contractAddress);
+    return firstHalf.concat(secondHalf);
+  }
 }
 
 export function decodeEvents(events: RawEvent[], timestampsCache: TimestampsCacheInterface, decodeFunctions: Record<string, DecodeEventFunction> = decodeFunctionsMap): ERC20Transfer[] {

--- a/src/blockchains/eth/lib/web3_wrapper.ts
+++ b/src/blockchains/eth/lib/web3_wrapper.ts
@@ -6,6 +6,7 @@ import { buildHttpOptions } from '../../../lib/build_http_options';
 export interface Web3Interface {
     getBlockNumber(): Promise<number>;
     getPastLogs(queryObject: any): Promise<any>;
+    getBlockReceipts(blockNumber: number): Promise<any[]>;
 }
 
 function containsOnly0Andx(input: string) {
@@ -28,6 +29,13 @@ export class Web3Wrapper implements Web3Interface {
 
     async getPastLogs(queryObject: any): Promise<any> {
         return await this.web3.eth.getPastLogs(queryObject);
+    }
+
+    async getBlockReceipts(blockNumber: number): Promise<any[]> {
+        return await this.web3.requestManager.send({
+            method: 'eth_getBlockReceipts',
+            params: [Web3Static.parseNumberToHex(blockNumber)]
+        });
     }
 
     async getBlock(blockNumber: number): Promise<any> {

--- a/src/test/erc20/fetch_events_fallback.spec.ts
+++ b/src/test/erc20/fetch_events_fallback.spec.ts
@@ -1,0 +1,104 @@
+import assert from 'assert';
+const rewire = require('rewire');
+
+const fetch_events = rewire('../../blockchains/erc20/lib/fetch_events');
+const getRawEvents = fetch_events.__get__('getRawEvents');
+
+const TOO_MANY_LOGS_ERROR = 'Returned error: query returns too many logs, narrow your filter: 20000';
+
+function makeLog(blockNumber: number, logIndex: number, address = '0x1111111111111111111111111111111111111111') {
+  return {
+    address,
+    blockNumber,
+    logIndex,
+    data: '0x0',
+    topics: ['0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef']
+  };
+}
+
+// A node mock where the block `hugeBlock` has too many logs to be served by eth_getLogs
+// and has to be fetched through eth_getBlockReceipts instead.
+class Web3WrapperMock {
+  hugeBlock: number;
+  receipts: any[];
+  getPastLogsCalls: Array<[number, number]> = [];
+  getBlockReceiptsCalls: number[] = [];
+
+  constructor(hugeBlock: number, receipts: any[]) {
+    this.hugeBlock = hugeBlock;
+    this.receipts = receipts;
+  }
+
+  async getPastLogs(queryObject: any): Promise<any> {
+    const fromBlock = parseInt(queryObject.fromBlock, 16);
+    const toBlock = parseInt(queryObject.toBlock, 16);
+    this.getPastLogsCalls.push([fromBlock, toBlock]);
+
+    if (fromBlock <= this.hugeBlock && this.hugeBlock <= toBlock) {
+      throw new Error(TOO_MANY_LOGS_ERROR);
+    }
+
+    const result = [];
+    for (let block = fromBlock; block <= toBlock; block++) {
+      result.push(makeLog(block, 0));
+    }
+    return result;
+  }
+
+  async getBlockReceipts(blockNumber: number): Promise<any[]> {
+    this.getBlockReceiptsCalls.push(blockNumber);
+    return this.receipts;
+  }
+}
+
+describe('getRawEvents fallback on too many logs', function () {
+  it('splits the interval and fetches the oversized block through receipts', async function () {
+    const receiptsLogs = [makeLog(104, 0), makeLog(104, 1), makeLog(104, 2)];
+    const web3Wrapper = new Web3WrapperMock(104, [
+      { logs: [receiptsLogs[0], receiptsLogs[1]] },
+      { logs: [receiptsLogs[2]] }
+    ]);
+
+    const result = await getRawEvents(web3Wrapper, 100, 107, null);
+
+    const expected = [
+      makeLog(100, 0), makeLog(101, 0), makeLog(102, 0), makeLog(103, 0),
+      ...receiptsLogs,
+      makeLog(105, 0), makeLog(106, 0), makeLog(107, 0)
+    ];
+    assert.deepStrictEqual(result, expected);
+    assert.deepStrictEqual(web3Wrapper.getBlockReceiptsCalls, [104]);
+  });
+
+  it('falls back to receipts when a single-block interval is oversized', async function () {
+    const web3Wrapper = new Web3WrapperMock(104, [{ logs: [makeLog(104, 0)] }]);
+
+    const result = await getRawEvents(web3Wrapper, 104, 104, null);
+
+    assert.deepStrictEqual(result, [makeLog(104, 0)]);
+    assert.deepStrictEqual(web3Wrapper.getPastLogsCalls, [[104, 104]]);
+    assert.deepStrictEqual(web3Wrapper.getBlockReceiptsCalls, [104]);
+  });
+
+  it('filters receipts logs by contract address on the fallback path', async function () {
+    const trackedLog = makeLog(104, 0, '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
+    const otherLog = makeLog(104, 1, '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb');
+    const web3Wrapper = new Web3WrapperMock(104, [{ logs: [trackedLog, otherLog] }]);
+
+    const result = await getRawEvents(web3Wrapper, 104, 104,
+      '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA');
+
+    assert.deepStrictEqual(result, [trackedLog]);
+  });
+
+  it('rethrows errors which are not about the logs limit', async function () {
+    const web3Wrapper = new Web3WrapperMock(104, []);
+    web3Wrapper.getPastLogs = async () => { throw new Error('connection refused'); };
+
+    await assert.rejects(
+      () => getRawEvents(web3Wrapper, 100, 107, null),
+      /connection refused/
+    );
+    assert.deepStrictEqual(web3Wrapper.getBlockReceiptsCalls, []);
+  });
+});

--- a/src/test/eth/mock_web3_wrapper.ts
+++ b/src/test/eth/mock_web3_wrapper.ts
@@ -15,6 +15,10 @@ export class MockWeb3Wrapper implements Web3Interface {
     throw Error("Should not be called")
   }
 
+  getBlockReceipts(blockNumber: number): Promise<any[]> {
+    throw Error("Should not be called")
+  }
+
 }
 
 export class MockEthClient {


### PR DESCRIPTION
## Problem

The ERC20 worker crashed on Ethereum with:

```
Returned error: query returns too many logs, narrow your filter: 20000
```

even with `BLOCK_INTERVAL` reduced to a single block. Since the worker fetches **all** logs in the range (the topics filter is commented out due to an old Parity bug), any block with more than 20000 logs is unfetchable via `eth_getLogs` — block 25649104 has 21176 logs (neighbors: ~700–1300), so no block batching can get under the limit.

## Fix

On the "too many logs" error, `getRawEvents` now:

1. recursively halves the block interval;
2. when a single block is still over the limit, fetches its logs via `eth_getBlockReceipts` (no response cap) and flattens the receipt logs.

The `contractAddress` filter is applied client-side on the fallback path; topic filtering already happens downstream in `decodeEvents`, so the output is identical to the normal path. Normal operation is unchanged — the fallback only runs on this specific error, other errors are rethrown as before.

## Tests

New `fetch_events_fallback.spec.ts` covers interval splitting + receipts fallback (ordering preserved, receipts fetched once), the single-block case, contract-address filtering on the fallback path, and that unrelated errors still propagate. All 229 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)