### PR TITLE
Multicall blacklist added

### DIFF
--- a/src/blockchains/erc20/erc20_worker.ts
+++ b/src/blockchains/erc20/erc20_worker.ts
@@ -70,7 +70,7 @@ export class ERC20Worker extends BaseWorker {
     this.contractsUnmodified = [];
     this.allOldContracts = [];
     this.blocksList = [];
-    this.multicallBlacklist = settings.MULTICALL_BLACKLIST_ENABLED
+    this.multicallBlacklist = settings.MULTICALL_BLACKLIST_FAILURE_THRESHOLD > 0
       ? new MulticallBlacklist(settings.MULTICALL_BLACKLIST_FAILURE_THRESHOLD)
       : null;
   }

--- a/src/blockchains/erc20/erc20_worker.ts
+++ b/src/blockchains/erc20/erc20_worker.ts
@@ -14,6 +14,7 @@ import { initBlocksList } from '../../lib/fetch_blocks_list';
 import { HTTPClientInterface } from '../../types';
 import { ERC20Transfer } from './erc20_types';
 import { extendTransfersWithBalances } from './lib/add_balances'
+import { MulticallBlacklist } from './lib/multicall_blacklist'
 import { buildInclusiveChunks } from './lib/chunk_utils';
 import { TrackingHttpClient, attachWeb3RequestTracker } from '../lib/request_tracking';
 
@@ -49,6 +50,7 @@ export class ERC20Worker extends BaseWorker {
 
   private allOldContracts: string[];
   private requestsSinceLastReport: number;
+  private multicallBlacklist: MulticallBlacklist | null;
 
 
   constructor(settings: any) {
@@ -68,6 +70,9 @@ export class ERC20Worker extends BaseWorker {
     this.contractsUnmodified = [];
     this.allOldContracts = [];
     this.blocksList = [];
+    this.multicallBlacklist = settings.MULTICALL_BLACKLIST_ENABLED
+      ? new MulticallBlacklist(settings.MULTICALL_BLACKLIST_FAILURE_THRESHOLD)
+      : null;
   }
 
   async init(exporter?: Exporter) {
@@ -165,7 +170,8 @@ export class ERC20Worker extends BaseWorker {
               oldEvents,
               this.settings.MULTICALL_BATCH_SIZE,
               this.settings.MAX_CONNECTION_CONCURRENCY,
-              this.settings.MULTICALL_ADDRESS
+              this.settings.MULTICALL_ADDRESS,
+              this.multicallBlacklist
             );
           }
           changeContractAddresses(oldEvents, this.contractsOverwriteArray);
@@ -187,7 +193,8 @@ export class ERC20Worker extends BaseWorker {
               rawEvents,
               this.settings.MULTICALL_BATCH_SIZE,
               this.settings.MAX_CONNECTION_CONCURRENCY,
-              this.settings.MULTICALL_ADDRESS
+              this.settings.MULTICALL_ADDRESS,
+              this.multicallBlacklist
             );
           }
           return rawEvents;
@@ -202,7 +209,7 @@ export class ERC20Worker extends BaseWorker {
       if (shouldExtendWithBalances) {
         await extendTransfersWithBalances((this.web3Wrapper as Web3Wrapper).getWeb3(), events,
           this.settings.MULTICALL_BATCH_SIZE, this.settings.MAX_CONNECTION_CONCURRENCY,
-          this.settings.MULTICALL_ADDRESS);
+          this.settings.MULTICALL_ADDRESS, this.multicallBlacklist);
       }
       if ('extract_all_append' === this.settings.CONTRACT_MODE) {
         overwritten_events = extractChangedContractAddresses(events, this.contractsOverwriteArray);

--- a/src/blockchains/erc20/lib/add_balances.ts
+++ b/src/blockchains/erc20/lib/add_balances.ts
@@ -6,6 +6,7 @@ import { MULTICALL_ADDRESS } from './constants';
 import * as Utils from './balance_utils';
 import { logger } from '../../../lib/logger';
 import { buildInclusiveChunks } from './chunk_utils';
+import { MulticallBlacklist } from './multicall_blacklist';
 
 const stringifyTransfer = (event: ERC20Transfer): string =>
   JSON.stringify(event, (_key, value) => typeof value === 'bigint' ? value.toString() : value);
@@ -50,8 +51,34 @@ function decodeMulticallResult(addressContractToMulticallResult: Utils.AddressCo
     }
   }
 
-  logger.warn(`Multicall partial failure at block ${blockNumber} for address-contract ${addressContract[0]}-${addressContract[1]}`)
   return [blockNumber, addressContract[0], addressContract[1], MULTICALL_FAILURE]
+}
+
+type ContractStats = Map<string, { failed: number, total: number }>;
+
+function computeContractStats(balances: Utils.BlockNumberAddressContractBalance[]): ContractStats {
+  const stats: ContractStats = new Map();
+  for (const [, , contract, balance] of balances) {
+    let contractStats = stats.get(contract);
+    if (!contractStats) {
+      contractStats = { failed: 0, total: 0 };
+      stats.set(contract, contractStats);
+    }
+    contractStats.total += 1;
+    if (balance === MULTICALL_FAILURE) {
+      contractStats.failed += 1;
+    }
+  }
+  return stats;
+}
+
+function logFailuresPerContract(stats: ContractStats, blockNumber: number) {
+  for (const [contract, contractStats] of Array.from(stats.entries())) {
+    if (contractStats.failed > 0) {
+      logger.warn(`Multicall partial failure at block ${blockNumber} for contract ${contract}: ` +
+        `${contractStats.failed}/${contractStats.total} addresses failed`);
+    }
+  }
 }
 
 async function executeNonBatchMulticall(web3: Web3, addressContracts: Utils.AddressContract[], blockNumber: number,
@@ -115,33 +142,83 @@ async function executeBatchMulticall(web3: Web3, addressContracts: Utils.Address
   return addressContracts.map((addressContract, index) => [addressContract, multicallResult[index]]);
 }
 
+// Split the pairs into ones which should be requested from the Node and ones belonging to
+// blacklisted contracts, which get marked as failure directly.
+function splitPerBlacklist(addressContracts: Utils.AddressContract[], blockNumber: number,
+  blacklist: MulticallBlacklist | null)
+  : { toRequest: Utils.AddressContract[], skipped: Utils.BlockNumberAddressContractBalance[] } {
+  if (blacklist === null) {
+    return { toRequest: addressContracts, skipped: [] };
+  }
+
+  const toRequest: Utils.AddressContract[] = [];
+  const skipped: Utils.BlockNumberAddressContractBalance[] = [];
+  for (const addressContract of addressContracts) {
+    if (blacklist.isBlacklisted(addressContract[1])) {
+      skipped.push([blockNumber, addressContract[0], addressContract[1], MULTICALL_FAILURE]);
+    }
+    else {
+      toRequest.push(addressContract);
+    }
+  }
+  return { toRequest, skipped };
+}
+
 async function getBalancesPerBlock(web3: Web3, addressContracts: Utils.AddressContract[], blockNumber: number,
-  multicallAddress: string = MULTICALL_ADDRESS)
+  multicallAddress: string = MULTICALL_ADDRESS, blacklist: MulticallBlacklist | null = null)
   : Promise<Utils.BlockNumberAddressContractBalance[]> {
 
+  const { toRequest, skipped } = splitPerBlacklist(addressContracts, blockNumber, blacklist);
+  if (toRequest.length === 0) {
+    return skipped;
+  }
+
   let rawMulticallResult: Utils.AddressContractToMulticallResult[] = []
+  let batchCallReturned = true;
   try {
-    rawMulticallResult = await executeBatchMulticall(web3, addressContracts, blockNumber, multicallAddress)
+    rawMulticallResult = await executeBatchMulticall(web3, toRequest, blockNumber, multicallAddress)
   }
   catch (error: any) {
     logger.warn(`Error calling multicall at block ${blockNumber}, would try without batching`)
+    batchCallReturned = false;
   }
 
-  if (rawMulticallResult.length === 0) {
-    rawMulticallResult = await executeNonBatchMulticall(web3, addressContracts, blockNumber, multicallAddress)
-    return rawMulticallResult.map((rawResult: Utils.AddressContractToMulticallResult) => {
+  if (!batchCallReturned) {
+    rawMulticallResult = await executeNonBatchMulticall(web3, toRequest, blockNumber, multicallAddress)
+  }
+
+  // A raw MULTICALL_FAILURE marks a request rejected at the RPC level on the non-batch fallback
+  // path. Fulfilled responses carrying an on-chain revert come through as result objects instead.
+  const contractsWithRpcFailure = new Set<string>();
+  const decoded: Utils.BlockNumberAddressContractBalance[] = rawMulticallResult.map(
+    (rawResult: Utils.AddressContractToMulticallResult) => {
       if (rawResult[1] === MULTICALL_FAILURE) {
-        // The balance call for this address-contract pair has failed. We would mark it as failure without decoding
+        contractsWithRpcFailure.add(rawResult[0][1]);
         return [blockNumber, rawResult[0][0], rawResult[0][1], MULTICALL_FAILURE]
       }
       else {
         return decodeMulticallResult(rawResult, web3, blockNumber)
       }
     })
+
+  const stats = computeContractStats(decoded);
+  logFailuresPerContract(stats, blockNumber);
+
+  // Successful resolutions and on-chain reverts inside fulfilled responses are clean signals on
+  // both the batch and the fallback path. RPC level rejections are not attributable to the
+  // contract, so a contract-wide failure involving one is not recorded.
+  if (blacklist !== null) {
+    for (const [contract, contractStats] of Array.from(stats.entries())) {
+      if (contractStats.failed < contractStats.total) {
+        blacklist.recordCleanResult(contract);
+      }
+      else if (!contractsWithRpcFailure.has(contract)) {
+        blacklist.recordAllFailed(contract, blockNumber)
+      }
+    }
   }
-  else {
-    return rawMulticallResult.map(rawResult => decodeMulticallResult(rawResult, web3, blockNumber))
-  }
+
+  return skipped.concat(decoded);
 }
 
 //Get all addresses invovled in transfers. Map them to the block where the transfer happened.
@@ -163,7 +240,8 @@ function identifyAddresses(events: ERC20Transfer[]): BlockNumberToAffectedAddres
 
 // Build a balance map for all addresses involved in transactions
 async function buildBalancesMap(web3: Web3, batchedAddresses: [number, Utils.AddressContract[]][],
-  maxConnectionConcurrency: number, multicallAddress: string = MULTICALL_ADDRESS): Promise<BlockNumberToBalances> {
+  maxConnectionConcurrency: number, multicallAddress: string = MULTICALL_ADDRESS,
+  blacklist: MulticallBlacklist | null = null): Promise<BlockNumberToBalances> {
   if (batchedAddresses.length === 0) {
     return new Map() as BlockNumberToBalances
   }
@@ -176,7 +254,7 @@ async function buildBalancesMap(web3: Web3, batchedAddresses: [number, Utils.Add
     const chunkResults: Utils.BlockNumberAddressContractBalance[] = []
     for (let idx = startIdx; idx <= endIdx; idx++) {
       const [blockNumber, addressContracts] = batchedAddresses[idx]
-      const balances = await getBalancesPerBlock(web3, addressContracts, blockNumber, multicallAddress)
+      const balances = await getBalancesPerBlock(web3, addressContracts, blockNumber, multicallAddress, blacklist)
       for (const balance of balances) {
         chunkResults.push(balance)
       }
@@ -203,7 +281,8 @@ async function buildBalancesMap(web3: Web3, batchedAddresses: [number, Utils.Add
 }
 
 export async function extendTransfersWithBalances(web3: Web3, events: ERC20Transfer[], multicallBatchSize: number,
-  maxConnectionConcurrency: number, multicallAddress: string = MULTICALL_ADDRESS) {
+  maxConnectionConcurrency: number, multicallAddress: string = MULTICALL_ADDRESS,
+  blacklist: MulticallBlacklist | null = null) {
   logger.info(`Enriching ${events.length} events with balances `);
   const addressesInvolved: BlockNumberToAffectedAddresses = identifyAddresses(events);
 
@@ -219,7 +298,8 @@ export async function extendTransfersWithBalances(web3: Web3, events: ERC20Trans
     })
   }
 
-  const balanceMap = await buildBalancesMap(web3, batchedAddresses, maxConnectionConcurrency, multicallAddress);
+  const balanceMap = await buildBalancesMap(web3, batchedAddresses, maxConnectionConcurrency, multicallAddress,
+    blacklist);
   for (const event of events) {
     if (Utils.isAddressEligableForBalance(event.from, event.contract)) {
       event.fromBalance = balanceMap.get(event.blockNumber)?.get(Utils.concatAddressAndContract(event.from, event.contract))

--- a/src/blockchains/erc20/lib/add_balances.ts
+++ b/src/blockchains/erc20/lib/add_balances.ts
@@ -175,16 +175,12 @@ async function fetchBalancesPerBlock(web3: Web3, addressContracts: Utils.Address
   : Promise<Utils.BlockNumberAddressContractBalance[]> {
 
   let rawMulticallResult: Utils.AddressContractToMulticallResult[] = []
-  let batchCallReturned = true;
+
   try {
     rawMulticallResult = await executeBatchMulticall(web3, addressContracts, blockNumber, multicallAddress)
   }
-  catch (error: any) {
+  catch {
     logger.warn(`Error calling multicall at block ${blockNumber}, would try without batching`)
-    batchCallReturned = false;
-  }
-
-  if (!batchCallReturned) {
     rawMulticallResult = await executeNonBatchMulticall(web3, addressContracts, blockNumber, multicallAddress)
   }
 

--- a/src/blockchains/erc20/lib/add_balances.ts
+++ b/src/blockchains/erc20/lib/add_balances.ts
@@ -169,6 +169,48 @@ function splitPerBlacklist(addressContracts: Utils.AddressContract[], blockNumbe
   return { toRequest, skipped };
 }
 
+// Request the balances from the Node, batched if possible, and decode the results.
+async function fetchBalancesPerBlock(web3: Web3, addressContracts: Utils.AddressContract[], blockNumber: number,
+  multicallAddress: string)
+  : Promise<Utils.BlockNumberAddressContractBalance[]> {
+
+  let rawMulticallResult: Utils.AddressContractToMulticallResult[] = []
+  let batchCallReturned = true;
+  try {
+    rawMulticallResult = await executeBatchMulticall(web3, addressContracts, blockNumber, multicallAddress)
+  }
+  catch (error: any) {
+    logger.warn(`Error calling multicall at block ${blockNumber}, would try without batching`)
+    batchCallReturned = false;
+  }
+
+  if (!batchCallReturned) {
+    rawMulticallResult = await executeNonBatchMulticall(web3, addressContracts, blockNumber, multicallAddress)
+  }
+
+  return rawMulticallResult.map(
+    (rawResult: Utils.AddressContractToMulticallResult) => {
+      if (rawResult[1] === MULTICALL_FAILURE) {
+        return [blockNumber, rawResult[0][0], rawResult[0][1], MULTICALL_FAILURE]
+      }
+      else {
+        return decodeMulticallResult(rawResult, web3, blockNumber)
+      }
+    })
+}
+
+// Feed the per-contract outcomes to the blacklist.
+function recordBlacklistSignals(stats: ContractStats, blockNumber: number, blacklist: MulticallBlacklist) {
+  for (const [contract, contractStats] of Array.from(stats.entries())) {
+    if (contractStats.failed < contractStats.total) {
+      blacklist.recordCleanResult(contract);
+    }
+    else {
+      blacklist.recordAllFailed(contract, blockNumber);
+    }
+  }
+}
+
 async function getBalancesPerBlock(web3: Web3, addressContracts: Utils.AddressContract[], blockNumber: number,
   multicallAddress: string = MULTICALL_ADDRESS, blacklist: MulticallBlacklist | null = null)
   : Promise<Utils.BlockNumberAddressContractBalance[]> {
@@ -178,52 +220,15 @@ async function getBalancesPerBlock(web3: Web3, addressContracts: Utils.AddressCo
     return skipped;
   }
 
-  let rawMulticallResult: Utils.AddressContractToMulticallResult[] = []
-  let batchCallReturned = true;
-  try {
-    rawMulticallResult = await executeBatchMulticall(web3, toRequest, blockNumber, multicallAddress)
-  }
-  catch (error: any) {
-    logger.warn(`Error calling multicall at block ${blockNumber}, would try without batching`)
-    batchCallReturned = false;
-  }
+  const balances = await fetchBalancesPerBlock(web3, toRequest, blockNumber, multicallAddress);
 
-  if (!batchCallReturned) {
-    rawMulticallResult = await executeNonBatchMulticall(web3, toRequest, blockNumber, multicallAddress)
-  }
-
-  // A raw MULTICALL_FAILURE marks a request rejected at the RPC level on the non-batch fallback
-  // path. Fulfilled responses carrying an on-chain revert come through as result objects instead.
-  const contractsWithRpcFailure = new Set<string>();
-  const decoded: Utils.BlockNumberAddressContractBalance[] = rawMulticallResult.map(
-    (rawResult: Utils.AddressContractToMulticallResult) => {
-      if (rawResult[1] === MULTICALL_FAILURE) {
-        contractsWithRpcFailure.add(rawResult[0][1]);
-        return [blockNumber, rawResult[0][0], rawResult[0][1], MULTICALL_FAILURE]
-      }
-      else {
-        return decodeMulticallResult(rawResult, web3, blockNumber)
-      }
-    })
-
-  const stats = computeContractStats(decoded);
+  const stats = computeContractStats(balances);
   logFailuresPerContract(stats, blockNumber);
-
-  // Successful resolutions and on-chain reverts inside fulfilled responses are clean signals on
-  // both the batch and the fallback path. RPC level rejections are not attributable to the
-  // contract, so a contract-wide failure involving one is not recorded.
   if (blacklist !== null) {
-    for (const [contract, contractStats] of Array.from(stats.entries())) {
-      if (contractStats.failed < contractStats.total) {
-        blacklist.recordCleanResult(contract);
-      }
-      else if (!contractsWithRpcFailure.has(contract)) {
-        blacklist.recordAllFailed(contract, blockNumber)
-      }
-    }
+    recordBlacklistSignals(stats, blockNumber, blacklist);
   }
 
-  return skipped.concat(decoded);
+  return skipped.concat(balances);
 }
 
 //Get all addresses invovled in transfers. Map them to the block where the transfer happened.

--- a/src/blockchains/erc20/lib/add_balances.ts
+++ b/src/blockchains/erc20/lib/add_balances.ts
@@ -110,6 +110,11 @@ async function executeNonBatchMulticall(web3: Web3, addressContracts: Utils.Addr
    * This fails on our endpoint but succeeds on Ankr due to different limits. However the response is a long sequence
    * of 0s.
    */
+  // If every individual call failed we are most probably facing a Node level problem. Erroring the
+  // export is preferred to marking all balances as failed and feeding noise to the blacklist.
+  if (errors.length > 0 && errors.length === addressContracts.length) {
+    throw new Error(`All ${errors.length} individual multicalls failed at block ${blockNumber}. First error is: ${errors[0]}`);
+  }
   if (errors.length > 0) {
     logger.warn(`${errors.length} errors out of ${addressContracts.length} in multicall at block ${blockNumber}. First errors is: ${errors[0]}`);
   }

--- a/src/blockchains/erc20/lib/constants.ts
+++ b/src/blockchains/erc20/lib/constants.ts
@@ -21,9 +21,8 @@ export const MULTICALL_DEPLOY_BLOCK = getIntEnvVariable('MULTICALL_DEPLOY_BLOCK'
 export const MULTICALL_BATCH_SIZE = getIntEnvVariable('MULTICALL_BATCH_SIZE', 50);
 export const MAX_CONNECTION_CONCURRENCY = Math.max(1, Math.floor(getIntEnvVariable('MAX_CONNECTION_CONCURRENCY', 10)));
 export const MULTICALL_ADDRESS = process.env.MULTICALL_ADDRESS || '0x5ba1e12693dc8f9c48aad8770482f4739beed696';
-// Skip balance requests for contracts which consistently fail 'balanceOf' inside successful Multicall responses
-export const MULTICALL_BLACKLIST_ENABLED = getBoolEnvVariable('MULTICALL_BLACKLIST_ENABLED', true);
-// Number of consecutive contract-wide failures before a contract gets blacklisted
+// Number of consecutive contract-wide 'balanceOf' failures before a contract is skipped in Multicall
+// requests. A value of 0 or less disables the blacklist.
 export const MULTICALL_BLACKLIST_FAILURE_THRESHOLD = getIntEnvVariable('MULTICALL_BLACKLIST_FAILURE_THRESHOLD', 5);
 
 export const CONTRACT_MAPPING_FILE_PATH = (

--- a/src/blockchains/erc20/lib/constants.ts
+++ b/src/blockchains/erc20/lib/constants.ts
@@ -21,6 +21,10 @@ export const MULTICALL_DEPLOY_BLOCK = getIntEnvVariable('MULTICALL_DEPLOY_BLOCK'
 export const MULTICALL_BATCH_SIZE = getIntEnvVariable('MULTICALL_BATCH_SIZE', 50);
 export const MAX_CONNECTION_CONCURRENCY = Math.max(1, Math.floor(getIntEnvVariable('MAX_CONNECTION_CONCURRENCY', 10)));
 export const MULTICALL_ADDRESS = process.env.MULTICALL_ADDRESS || '0x5ba1e12693dc8f9c48aad8770482f4739beed696';
+// Skip balance requests for contracts which consistently fail 'balanceOf' inside successful Multicall responses
+export const MULTICALL_BLACKLIST_ENABLED = getBoolEnvVariable('MULTICALL_BLACKLIST_ENABLED', true);
+// Number of consecutive contract-wide failures before a contract gets blacklisted
+export const MULTICALL_BLACKLIST_FAILURE_THRESHOLD = getIntEnvVariable('MULTICALL_BLACKLIST_FAILURE_THRESHOLD', 5);
 
 export const CONTRACT_MAPPING_FILE_PATH = (
     process.env.CONTRACT_MAPPING_FILE_PATH ?

--- a/src/blockchains/erc20/lib/multicall_blacklist.ts
+++ b/src/blockchains/erc20/lib/multicall_blacklist.ts
@@ -1,10 +1,9 @@
 import { logger } from '../../../lib/logger';
 
 /**
- * Tracks ERC20 contracts whose 'balanceOf' consistently fails with a clean on-chain revert (the
- * request carrying the call succeeded). After 'failureThreshold' consecutive contract-wide
- * failures a contract is blacklisted and its balance requests are skipped. A success before the
- * threshold is reached resets the count.
+ * Tracks ERC20 contracts whose 'balanceOf' consistently fails in Multicall requests. After
+ * 'failureThreshold' consecutive contract-wide failures a contract is blacklisted and its balance
+ * requests are skipped. A success before the threshold is reached resets the count.
  *
  * The state is in-memory only: a blacklisted contract stays skipped for the lifetime of the
  * process and gets re-evaluated from scratch on restart.

--- a/src/blockchains/erc20/lib/multicall_blacklist.ts
+++ b/src/blockchains/erc20/lib/multicall_blacklist.ts
@@ -12,7 +12,6 @@ import { logger } from '../../../lib/logger';
 export class MulticallBlacklist {
   private readonly failureThreshold: number;
   private consecutiveFailures: Map<string, number> = new Map();
-  private blacklisted: Set<string> = new Set();
 
   constructor(failureThreshold: number) {
     this.failureThreshold = failureThreshold;
@@ -22,14 +21,10 @@ export class MulticallBlacklist {
   // clean on-chain reverts.
   recordAllFailed(contract: string, blockNumber: number) {
     const failures = (this.consecutiveFailures.get(contract) ?? 0) + 1;
-    if (failures >= this.failureThreshold) {
-      this.consecutiveFailures.delete(contract);
-      this.blacklisted.add(contract);
+    this.consecutiveFailures.set(contract, failures);
+    if (failures === this.failureThreshold) {
       logger.info(`Blacklisting contract ${contract} at block ${blockNumber} after ` +
         `${this.failureThreshold} consecutive contract-wide multicall failures`);
-    }
-    else {
-      this.consecutiveFailures.set(contract, failures);
     }
   }
 
@@ -39,6 +34,6 @@ export class MulticallBlacklist {
   }
 
   isBlacklisted(contract: string): boolean {
-    return this.blacklisted.has(contract);
+    return (this.consecutiveFailures.get(contract) ?? 0) >= this.failureThreshold;
   }
 }

--- a/src/blockchains/erc20/lib/multicall_blacklist.ts
+++ b/src/blockchains/erc20/lib/multicall_blacklist.ts
@@ -1,0 +1,44 @@
+import { logger } from '../../../lib/logger';
+
+/**
+ * Tracks ERC20 contracts whose 'balanceOf' consistently fails with a clean on-chain revert (the
+ * request carrying the call succeeded). After 'failureThreshold' consecutive contract-wide
+ * failures a contract is blacklisted and its balance requests are skipped. A success before the
+ * threshold is reached resets the count.
+ *
+ * The state is in-memory only: a blacklisted contract stays skipped for the lifetime of the
+ * process and gets re-evaluated from scratch on restart.
+ */
+export class MulticallBlacklist {
+  private readonly failureThreshold: number;
+  private consecutiveFailures: Map<string, number> = new Map();
+  private blacklisted: Set<string> = new Set();
+
+  constructor(failureThreshold: number) {
+    this.failureThreshold = failureThreshold;
+  }
+
+  // Record that every queried address of the contract failed to resolve, with all failures being
+  // clean on-chain reverts.
+  recordAllFailed(contract: string, blockNumber: number) {
+    const failures = (this.consecutiveFailures.get(contract) ?? 0) + 1;
+    if (failures >= this.failureThreshold) {
+      this.consecutiveFailures.delete(contract);
+      this.blacklisted.add(contract);
+      logger.info(`Blacklisting contract ${contract} at block ${blockNumber} after ` +
+        `${this.failureThreshold} consecutive contract-wide multicall failures`);
+    }
+    else {
+      this.consecutiveFailures.set(contract, failures);
+    }
+  }
+
+  // Record that at least one queried address of the contract resolved successfully.
+  recordCleanResult(contract: string) {
+    this.consecutiveFailures.delete(contract);
+  }
+
+  isBlacklisted(contract: string): boolean {
+    return this.blacklisted.has(contract);
+  }
+}

--- a/src/test/erc20/add_balances.spec.ts
+++ b/src/test/erc20/add_balances.spec.ts
@@ -387,7 +387,7 @@ describe('test multicall blacklist integration', function () {
     assert.strictEqual(blacklist.isBlacklisted('contract1'), true);
   });
 
-  it('contract-wide failure including an RPC level rejection is not recorded', async function () {
+  it('contract-wide failure mixing an RPC level rejection is recorded', async function () {
     const blacklist = new MulticallBlacklist(1);
 
     // The batch is rejected, then one individual call is rejected while the other returns a revert
@@ -410,6 +410,6 @@ describe('test multicall blacklist integration', function () {
       [10, 'address1', 'contract1', MULTICALL_FAILURE],
       [10, 'address2', 'contract1', MULTICALL_FAILURE]
     ]);
-    assert.strictEqual(blacklist.isBlacklisted('contract1'), false);
+    assert.strictEqual(blacklist.isBlacklisted('contract1'), true);
   });
 });

--- a/src/test/erc20/add_balances.spec.ts
+++ b/src/test/erc20/add_balances.spec.ts
@@ -355,7 +355,7 @@ describe('test multicall blacklist integration', function () {
     assert.strictEqual(blacklist.isBlacklisted('contract1'), false);
   });
 
-  it('RPC level rejections on the fallback path are not recorded', async function () {
+  it('all calls failing at the RPC level is a non recoverable error', async function () {
     const blacklist = new MulticallBlacklist(1);
 
     // Both the batch and the individual calls fail at the RPC level
@@ -363,10 +363,10 @@ describe('test multicall blacklist integration', function () {
     add_balances_rewired.__set__('doMulticall', doMulticallMock);
 
     const getBalancesPerBlock = add_balances_rewired.__get__('getBalancesPerBlock');
-    const result = await getBalancesPerBlock(web3Mock, [['address1', 'contract1']], 10,
-      'multicallAddress', blacklist);
-
-    assert.deepStrictEqual(result, [[10, 'address1', 'contract1', MULTICALL_FAILURE]]);
+    await assert.rejects(
+      () => getBalancesPerBlock(web3Mock, [['address1', 'contract1']], 10, 'multicallAddress', blacklist),
+      /All 1 individual multicalls failed at block 10/
+    );
     assert.strictEqual(blacklist.isBlacklisted('contract1'), false);
   });
 

--- a/src/test/erc20/add_balances.spec.ts
+++ b/src/test/erc20/add_balances.spec.ts
@@ -3,6 +3,7 @@ const rewire = require('rewire');
 const sinon = require('sinon');
 
 import { MULTICALL_FAILURE } from '../../blockchains/erc20/lib/add_balances';
+import { MulticallBlacklist } from '../../blockchains/erc20/lib/multicall_blacklist';
 
 const add_balances_rewired = rewire('../../blockchains/erc20/lib/add_balances.ts');
 import * as Utils from '../../blockchains/erc20/lib/balance_utils';
@@ -283,5 +284,132 @@ describe('test execute Multicall', function () {
     const expected = [[addressContract1, multicallResultAddress1], [addressContract2, multicallResultAddress2]]
 
     assert.deepStrictEqual(result, expected)
+  });
+});
+
+describe('test multicall blacklist integration', function () {
+  let doMulticallOriginal: any = null;
+
+  const failureResult = { "0": false, "1": "0x", "__length__": 2, "success": false, "returnData": "0x" };
+  const successResult = { "0": true, "1": "0x00000000000000000000000000000000000000000000000000000000000000ff", "__length__": 2, "success": true, "returnData": "0x00000000000000000000000000000000000000000000000000000000000000ff" };
+  const web3Mock = { eth: { abi: { decodeParameter: () => 255n } } };
+
+  beforeEach(function () {
+    doMulticallOriginal = add_balances_rewired.__get__('doMulticall');
+  })
+
+  afterEach(function () {
+    add_balances_rewired.__set__('doMulticall', doMulticallOriginal);
+  })
+
+  it('blacklisted contract is not requested from the node', async function () {
+    const blacklist = new MulticallBlacklist(1);
+    blacklist.recordAllFailed('contract1', 1);
+    assert.strictEqual(blacklist.isBlacklisted('contract1'), true);
+
+    const doMulticallMock = sinon.stub().callsFake(
+      (_web3: any, _blockNumber: number, addressContracts: Utils.AddressContract[]) => {
+        assert.deepStrictEqual(addressContracts, [['address2', 'contract2']]);
+        return Promise.resolve([successResult]);
+      });
+    add_balances_rewired.__set__('doMulticall', doMulticallMock);
+
+    const getBalancesPerBlock = add_balances_rewired.__get__('getBalancesPerBlock');
+    const result = await getBalancesPerBlock(web3Mock,
+      [['address1', 'contract1'], ['address2', 'contract2']], 2, 'multicallAddress', blacklist);
+
+    const expected = [
+      [2, 'address1', 'contract1', MULTICALL_FAILURE],
+      [2, 'address2', 'contract2', (255n).toString(36)]
+    ];
+    assert.deepStrictEqual(result, expected);
+    assert.strictEqual(doMulticallMock.callCount, 1);
+  });
+
+  it('contract-wide failures in successful batches lead to blacklisting', async function () {
+    const blacklist = new MulticallBlacklist(2);
+
+    const doMulticallMock = sinon.stub().resolves([failureResult, failureResult]);
+    add_balances_rewired.__set__('doMulticall', doMulticallMock);
+
+    const getBalancesPerBlock = add_balances_rewired.__get__('getBalancesPerBlock');
+    const addressContracts = [['address1', 'contract1'], ['address2', 'contract1']];
+
+    await getBalancesPerBlock(web3Mock, addressContracts, 10, 'multicallAddress', blacklist);
+    assert.strictEqual(blacklist.isBlacklisted('contract1'), false);
+
+    await getBalancesPerBlock(web3Mock, addressContracts, 11, 'multicallAddress', blacklist);
+    assert.strictEqual(blacklist.isBlacklisted('contract1'), true);
+  });
+
+  it('partial success within a contract is not counted towards blacklisting', async function () {
+    const blacklist = new MulticallBlacklist(1);
+
+    const doMulticallMock = sinon.stub().resolves([failureResult, successResult]);
+    add_balances_rewired.__set__('doMulticall', doMulticallMock);
+
+    const getBalancesPerBlock = add_balances_rewired.__get__('getBalancesPerBlock');
+    await getBalancesPerBlock(web3Mock, [['address1', 'contract1'], ['address2', 'contract1']], 10,
+      'multicallAddress', blacklist);
+
+    assert.strictEqual(blacklist.isBlacklisted('contract1'), false);
+  });
+
+  it('RPC level rejections on the fallback path are not recorded', async function () {
+    const blacklist = new MulticallBlacklist(1);
+
+    // Both the batch and the individual calls fail at the RPC level
+    const doMulticallMock = sinon.stub().rejects(new Error('Mocked RPC error'));
+    add_balances_rewired.__set__('doMulticall', doMulticallMock);
+
+    const getBalancesPerBlock = add_balances_rewired.__get__('getBalancesPerBlock');
+    const result = await getBalancesPerBlock(web3Mock, [['address1', 'contract1']], 10,
+      'multicallAddress', blacklist);
+
+    assert.deepStrictEqual(result, [[10, 'address1', 'contract1', MULTICALL_FAILURE]]);
+    assert.strictEqual(blacklist.isBlacklisted('contract1'), false);
+  });
+
+  it('reverts inside fulfilled responses on the fallback path are recorded', async function () {
+    const blacklist = new MulticallBlacklist(1);
+
+    // The batch request is rejected at the RPC level, the individual call returns an on-chain revert
+    const doMulticallMock = sinon.stub();
+    doMulticallMock.onFirstCall().rejects(new Error('Mocked RPC error'));
+    doMulticallMock.resolves([failureResult]);
+    add_balances_rewired.__set__('doMulticall', doMulticallMock);
+
+    const getBalancesPerBlock = add_balances_rewired.__get__('getBalancesPerBlock');
+    const result = await getBalancesPerBlock(web3Mock, [['address1', 'contract1']], 10,
+      'multicallAddress', blacklist);
+
+    assert.deepStrictEqual(result, [[10, 'address1', 'contract1', MULTICALL_FAILURE]]);
+    assert.strictEqual(blacklist.isBlacklisted('contract1'), true);
+  });
+
+  it('contract-wide failure including an RPC level rejection is not recorded', async function () {
+    const blacklist = new MulticallBlacklist(1);
+
+    // The batch is rejected, then one individual call is rejected while the other returns a revert
+    const doMulticallMock = sinon.stub().callsFake(
+      (_web3: any, _blockNumber: number, addressContracts: Utils.AddressContract[]) => {
+        if (addressContracts.length > 1) {
+          return Promise.reject(new Error('Mocked batch RPC error'));
+        }
+        return addressContracts[0][0] === 'address1'
+          ? Promise.reject(new Error('Mocked RPC error'))
+          : Promise.resolve([failureResult]);
+      });
+    add_balances_rewired.__set__('doMulticall', doMulticallMock);
+
+    const getBalancesPerBlock = add_balances_rewired.__get__('getBalancesPerBlock');
+    const result = await getBalancesPerBlock(web3Mock,
+      [['address1', 'contract1'], ['address2', 'contract1']], 10, 'multicallAddress', blacklist);
+
+    assert.deepStrictEqual(result, [
+      [10, 'address1', 'contract1', MULTICALL_FAILURE],
+      [10, 'address2', 'contract1', MULTICALL_FAILURE]
+    ]);
+    assert.strictEqual(blacklist.isBlacklisted('contract1'), false);
   });
 });

--- a/src/test/erc20/multicall_blacklist.spec.ts
+++ b/src/test/erc20/multicall_blacklist.spec.ts
@@ -1,0 +1,38 @@
+const assert = require('assert');
+
+import { MulticallBlacklist } from '../../blockchains/erc20/lib/multicall_blacklist';
+
+const CONTRACT = '0xaa8a56638b9f91fffa3188693731a8fcbcf40a3b';
+
+describe('MulticallBlacklist', function () {
+  it('contract is blacklisted after enough consecutive contract-wide failures', function () {
+    const blacklist = new MulticallBlacklist(3);
+
+    blacklist.recordAllFailed(CONTRACT, 100);
+    blacklist.recordAllFailed(CONTRACT, 101);
+    assert.strictEqual(blacklist.isBlacklisted(CONTRACT), false);
+
+    blacklist.recordAllFailed(CONTRACT, 102);
+    assert.strictEqual(blacklist.isBlacklisted(CONTRACT), true);
+  });
+
+  it('a successful resolution resets the failure count', function () {
+    const blacklist = new MulticallBlacklist(2);
+
+    blacklist.recordAllFailed(CONTRACT, 100);
+    blacklist.recordCleanResult(CONTRACT);
+    blacklist.recordAllFailed(CONTRACT, 102);
+    assert.strictEqual(blacklist.isBlacklisted(CONTRACT), false);
+
+    blacklist.recordAllFailed(CONTRACT, 103);
+    assert.strictEqual(blacklist.isBlacklisted(CONTRACT), true);
+  });
+
+  it('contracts are tracked independently', function () {
+    const blacklist = new MulticallBlacklist(1);
+
+    blacklist.recordAllFailed(CONTRACT, 100);
+    assert.strictEqual(blacklist.isBlacklisted(CONTRACT), true);
+    assert.strictEqual(blacklist.isBlacklisted('0xother'), false);
+  });
+});


### PR DESCRIPTION
A multicall blacklist. When a contract fails a multicall several times - blacklist it to unload the API load and also improve on logging.

Our logs were full of a small set of contracts failing the multicall `balanceOf` we do. So decided to both minimize the logging and reduce the api load be excluding those through a blacklist.

The blacklist is not persisted across restarts. Consider this implementation but a) it's a bit more complex b) it's unclear under what conditions we want to allow for rehabilitation. Maybe a contract got updated and do not fail anymore.