### PR TITLE
Add 'ignore-scripts=true' as a safety measure

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=true

--- a/README.md
+++ b/README.md
@@ -27,7 +27,10 @@ asdf current nodejs
 
 ```bash
 npm ci
+npm rebuild node-rdkafka --ignore-scripts=false
 ```
+
+The repository `.npmrc` sets `ignore-scripts=true` so that dependency lifecycle scripts do not run on install (protection against npm supply-chain attacks that deliver payloads via `preinstall` hooks). The one dependency that legitimately needs an install script is `node-rdkafka` (native compile), hence the explicit rebuild with `--ignore-scripts=false` after every install.
 
 Useful `asdf` commands:
 
@@ -42,7 +45,7 @@ asdf shell nodejs 21.4.0
 asdf local nodejs 21.4.0
 ```
 
-`node-rdkafka` is a native module. If you switch Node.js versions after installing dependencies, rerun `npm ci` (or at least rebuild that module) so native bindings match the active Node.js version.
+`node-rdkafka` is a native module. If you switch Node.js versions after installing dependencies, rerun `npm rebuild node-rdkafka --ignore-scripts=false` so native bindings match the active Node.js version.
 
 ## Run
 
@@ -52,6 +55,7 @@ For local development:
 
 ```bash
 npm ci
+npm rebuild node-rdkafka --ignore-scripts=false
 npm run build
 npm start
 ```
@@ -91,6 +95,7 @@ You can run the unit tests in one of the following ways:
 Use Node.js `21.4.0` locally to match the Docker image and `.tool-versions`.
 ```bash
 $ npm ci
+$ npm rebuild node-rdkafka --ignore-scripts=false
 $ npm test
 ```
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,10 +8,12 @@ RUN apt-get update && \
 
 WORKDIR /opt
 
-COPY package.json package-lock.json tsconfig.json copy_assets.sh .mocharc.js ./
+COPY package.json package-lock.json .npmrc tsconfig.json copy_assets.sh .mocharc.js ./
 COPY src ./src
 
-RUN echo "BUILD_ENV is $BUILD_ENV" && npm ci && npm run build
+# .npmrc sets ignore-scripts=true (supply-chain protection), so the native
+# build of node-rdkafka must be triggered explicitly after install.
+RUN echo "BUILD_ENV is $BUILD_ENV" && npm ci && npm rebuild node-rdkafka --ignore-scripts=false && npm run build
 
 # Verify that directories are created. Then prepare 'app' directory
 RUN ls -la /opt && \


### PR DESCRIPTION
* We disable ignore scripts by default, this buys as some protection from supply chain attacks which usually execute a script.
* One of our dependancies genuinely needs a script to build - noderdkafka, for it we enable it explicitly.